### PR TITLE
feat: Support poetry version format >= 1.5.0

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -1,3 +1,5 @@
+# This workflow will bump the version of our project once is merged
+
 name: Bump version
 
 on:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,5 @@
+# This workflow will check our code for having a proper format, as well as the commit message to meet the expected ones
+
 name: Lint
 
 on:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,4 @@
+# This workflow will publish our package on pypi
 
 name: Publish
 
@@ -12,9 +13,7 @@ permissions:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Publish python package

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+# This workflow will run some security checks against our project
 
 name: Security
 
@@ -32,6 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+# This workflow will install Python dependencies, and run the tests for our project
 
 name: Test
 
@@ -14,15 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.11"
     - name: Install just
       run: |
         sudo apt update
@@ -35,4 +32,4 @@ jobs:
 
     - name: Test with pytest
       run: |
-        just python_version=python${{ matrix.python-version }} test
+        just test

--- a/src/twyn/dependency_parser/poetry_lock.py
+++ b/src/twyn/dependency_parser/poetry_lock.py
@@ -1,8 +1,6 @@
 """Parser for poetry.lock dependencies."""
-
-
-from dparse import filetypes, parse
-from dparse.dependencies import Dependency, DependencyFile
+import tomllib
+from dparse import filetypes
 
 from twyn.dependency_parser.abstract_parser import AbstractParser
 
@@ -15,8 +13,5 @@ class PoetryLockParser(AbstractParser):
 
     def parse(self) -> set[str]:
         """Parse poetry.lock dependencies into set of dependency names."""
-        dependency_file: DependencyFile = parse(
-            self._read(), file_type=filetypes.poetry_lock
-        )
-        dependencies: list[Dependency] = dependency_file.resolved_dependencies
-        return {dependency.name for dependency in dependencies}
+        data = tomllib.loads(self._read())
+        return {dependency["name"] for dependency in data["package"]}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,8 @@ def requirements_txt_file(tmp_path):
 
 
 @pytest.fixture
-def poetry_lock_file(tmp_path):
+def poetry_lock_file_lt_1_5(tmp_path):
+    """Poetry lock version < 1.5."""
     poetry_lock_file = tmp_path / "poetry.lock"
     poetry_lock_file.write_text(
         """
@@ -46,6 +47,52 @@ def poetry_lock_file(tmp_path):
             version = "0.7.0"
             description = "McCabe checker, plugin for flake8"
             category = "dev"
+            optional = false
+            python-versions = ">=3.6"
+
+            [metadata]
+            lock-version = "1.1"
+            python-versions = "^3.9"
+            content-hash = "d518428f67ed390edb669028a3136be9a363472e206d4dec455af35381e"
+
+            [metadata.files]
+            charset-normalizer = []
+            flake8 = []
+            mccabe = []
+        """
+    )
+    yield poetry_lock_file
+    os.remove(poetry_lock_file)
+
+
+@pytest.fixture
+def poetry_lock_file_ge_1_5(tmp_path):
+    """Poetry lock version >= 1.5."""
+    poetry_lock_file = tmp_path / "poetry.lock"
+    poetry_lock_file.write_text(
+        """
+            [[package]]
+            name = "charset-normalizer"
+            version = "3.0.1"
+            description = "The Real First Universal Charset Detector. Open, modern and \
+                actively maintained alternative to Chardet."
+            optional = false
+            python-versions = "*"
+
+            [[package]]
+            name = "flake8"
+            version = "5.0.4"
+            description = "the modular source code checker: pep8 pyflakes and co"
+            optional = false
+            python-versions = ">=3.6.1"
+
+            [package.dependencies]
+            mccabe = ">=0.7.0,<0.8.0"
+
+            [[package]]
+            name = "mccabe"
+            version = "0.7.0"
+            description = "McCabe checker, plugin for flake8"
             optional = false
             python-versions = ">=3.6"
 

--- a/tests/dependency_parser/test_dependency_parser.py
+++ b/tests/dependency_parser/test_dependency_parser.py
@@ -52,6 +52,10 @@ class TestRequirementsTxtParser:
 
 
 class TestPoetryLockParser:
-    def test_parse_poetry_lock_file(self, poetry_lock_file):
-        parser = PoetryLockParser(file_path=poetry_lock_file)
+    def test_parse_poetry_lock_file_lt_1_5(self, poetry_lock_file_lt_1_5):
+        parser = PoetryLockParser(file_path=poetry_lock_file_lt_1_5)
+        assert parser.parse() == {"charset-normalizer", "flake8", "mccabe"}
+
+    def test_parse_poetry_lock_file_ge_1_5(self, poetry_lock_file_ge_1_5):
+        parser = PoetryLockParser(file_path=poetry_lock_file_ge_1_5)
         assert parser.parse() == {"charset-normalizer", "flake8", "mccabe"}


### PR DESCRIPTION
We've been blocked by dparse library not being able to parse newest poetry lock versions, which was making our pipelines fail since we run twyn against our dependencies. We will consider completely dropping the usage of dparse, to make Twyn more lightweight.

Since we now require `tomllib`, which is present on Python versions 3.11 onwards, and this tool is now meant to be run standalone (meaning, not as a package), we're also dropping the tests against previous Python versions.

Also added some comments to the workflow files.