### PR TITLE
fix: select file from paths that are not in the root folder

### DIFF
--- a/src/twyn/cli.py
+++ b/src/twyn/cli.py
@@ -23,7 +23,7 @@ def entry_point() -> None:
 @click.option("--config", type=click.STRING)
 @click.option(
     "--dependency-file",
-    type=click.Choice(list(DEPENDENCY_FILE_MAPPING.keys())),
+    type=str,
     help=(
         "Dependency file to analyze. By default, twyn will search in the current directory "
         "for supported files, but this option will override that behavior."
@@ -76,6 +76,9 @@ def run(
 
     if dependency and dependency_file:
         raise ValueError("Only one of --dependency or --dependency-file can be set at a time.")
+
+    if dependency_file and not any(dependency_file.endswith(key) for key in DEPENDENCY_FILE_MAPPING):
+        raise ValueError("Dependency file name not supported.")
 
     return int(
         check_dependencies(

--- a/src/twyn/dependency_parser/dependency_selector.py
+++ b/src/twyn/dependency_parser/dependency_selector.py
@@ -50,11 +50,12 @@ class DependencySelector:
         if self.dependency_file:
             logger.debug("Dependency file provided. Assigning a parser.")
             dependency_file_parser = self.get_dependency_file_parser_from_file_name()
+            file_parser = dependency_file_parser(self.dependency_file)
         else:
             logger.debug("No dependency file provided. Attempting to locate one.")
             dependency_file_parser = self.auto_detect_dependency_file_parser()
+            file_parser = dependency_file_parser()
 
-        file_parser = dependency_file_parser()
         logger.debug(f"Assigned {file_parser} parser for local dependencies file.")
 
         return file_parser

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,28 +1,36 @@
 import os
-from typing import Generator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
 
 import pytest
 
 
+@contextmanager
+def create_tmp_file(path: Path, data: str) -> Iterator[str]:
+    path.write_text(data)
+    yield str(path)
+    os.remove(path)
+
+
 @pytest.fixture
-def requirements_txt_file(tmp_path) -> Generator[str, None, None]:
+def requirements_txt_file(tmp_path: Path) -> Iterator[str]:
     requirements_txt_file = tmp_path / "requirements.txt"
-    requirements_txt_file.write_text(
-        """
+
+    data = """
         South==1.0.1 --hash=sha256:abcdefghijklmno
         pycrypto>=2.6
         """
-    )
-    yield str(requirements_txt_file)
-    os.remove(requirements_txt_file)
+
+    with create_tmp_file(requirements_txt_file, data) as tmp_file:
+        yield tmp_file
 
 
 @pytest.fixture
-def poetry_lock_file_lt_1_5(tmp_path) -> Generator[str, None, None]:
+def poetry_lock_file_lt_1_5(tmp_path: Path) -> Iterator[str]:
     """Poetry lock version < 1.5."""
     poetry_lock_file = tmp_path / "poetry.lock"
-    poetry_lock_file.write_text(
-        """
+    data = """
             [[package]]
             name = "charset-normalizer"
             version = "3.0.1"
@@ -61,17 +69,15 @@ def poetry_lock_file_lt_1_5(tmp_path) -> Generator[str, None, None]:
             flake8 = []
             mccabe = []
         """
-    )
-    yield str(poetry_lock_file)
-    os.remove(poetry_lock_file)
+    with create_tmp_file(poetry_lock_file, data) as tmp_file:
+        yield tmp_file
 
 
 @pytest.fixture
-def poetry_lock_file_ge_1_5(tmp_path) -> Generator[str, None, None]:
+def poetry_lock_file_ge_1_5(tmp_path: Path) -> Iterator[str]:
     """Poetry lock version >= 1.5."""
     poetry_lock_file = tmp_path / "poetry.lock"
-    poetry_lock_file.write_text(
-        """
+    data = """
             [[package]]
             name = "charset-normalizer"
             version = "3.0.1"
@@ -107,16 +113,14 @@ def poetry_lock_file_ge_1_5(tmp_path) -> Generator[str, None, None]:
             flake8 = []
             mccabe = []
         """
-    )
-    yield str(poetry_lock_file)
-    os.remove(poetry_lock_file)
+    with create_tmp_file(poetry_lock_file, data) as tmp_file:
+        yield tmp_file
 
 
 @pytest.fixture
-def pyproject_toml_file(tmp_path) -> Generator[str, None, None]:
+def pyproject_toml_file(tmp_path: Path) -> Iterator[str]:
     pyproject_toml = tmp_path / "pyproject.toml"
-    pyproject_toml.write_text(
-        """
+    data = """
     [tool.poetry.dependencies]
     python = "^3.11"
     requests = "^2.28.2"
@@ -136,6 +140,5 @@ def pyproject_toml_file(tmp_path) -> Generator[str, None, None]:
     allowlist=["boto4", "boto2"]
 
     """
-    )
-    yield str(pyproject_toml)
-    os.remove(pyproject_toml)
+    with create_tmp_file(pyproject_toml, data) as tmp_file:
+        yield tmp_file

--- a/tests/main/test_cli.py
+++ b/tests/main/test_cli.py
@@ -54,6 +54,27 @@ class TestCli:
         ]
 
     @patch("twyn.cli.check_dependencies")
+    def test_click_arguments_dependency_file_in_different_path(self, mock_check_dependencies):
+        runner = CliRunner()
+        runner.invoke(
+            cli.run,
+            [
+                "--dependency-file",
+                "/path/requirements.txt",
+            ],
+        )
+
+        assert mock_check_dependencies.call_args_list == [
+            call(
+                config_file=None,
+                dependency_file="/path/requirements.txt",
+                dependencies_cli=None,
+                selector_method=None,
+                verbosity=AvailableLoggingLevels.none,
+            )
+        ]
+
+    @patch("twyn.cli.check_dependencies")
     def test_click_arguments_single_dependency_cli(self, mock_check_dependencies):
         runner = CliRunner()
         runner.invoke(
@@ -128,3 +149,11 @@ class TestCli:
             match="Only one verbosity level is allowed. Choose either -v or -vv.",
         ):
             runner.invoke(cli.run, ["-v", "-vv"], catch_exceptions=False)
+
+    def test_dependency_file_name_has_to_be_recognized(self):
+        runner = CliRunner()
+        with pytest.raises(
+            ValueError,
+            match="Dependency file name not supported.",
+        ):
+            runner.invoke(cli.run, ["--dependency-file", "requirements-dev.txt"], catch_exceptions=False)

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -10,6 +10,8 @@ from twyn.main import (
     get_parsed_dependencies_from_file,
 )
 
+from tests.conftest import create_tmp_file
+
 
 @pytest.mark.usefixtures("disable_track")
 class TestCheckDependencies:
@@ -164,6 +166,23 @@ class TestCheckDependencies:
             dependencies_cli={package_name},
             selector_method="first-letter",
         )
+
+        assert error is True
+
+    @patch("twyn.main.TopPyPiReference")
+    def test_check_dependencies_with_input_loads_file_from_different_location(
+        self, mock_top_pypi_reference, tmp_path, tmpdir
+    ):
+        mock_top_pypi_reference.return_value.get_packages.return_value = {"mypackage"}
+        tmpdir.mkdir("fake-dir")
+        tmp_file = tmp_path / "fake-dir" / "requirements.txt"
+        with create_tmp_file(tmp_file, "mypackag"):
+            error = check_dependencies(
+                config_file=None,
+                dependency_file=str(tmp_file),
+                dependencies_cli=None,
+                selector_method="first-letter",
+            )
 
         assert error is True
 


### PR DESCRIPTION
Now Twyn  can load a file that is not in the root directory.

We still check for the name of the file, which has to be one of the supported ones (`poetry.lock` or `requirements.txt`).

This PR is for fixing the bug, but in the future Twyn should support any name in the file (i.e. `requirements-dev.txt`) #158. 