### PR TITLE
fix: move docker to python 3.13 and change entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 
 RUN pip install twyn
 
-ENTRYPOINT ["twyn", "run", "-vv"]
+ENTRYPOINT ["twyn"]


### PR DESCRIPTION
The entrypoint of a docker image for a tool should be the tool entrypoint and contain no args.

Otherwise users cannot call other options (like `--help` or whatever).

Also moving to the latest supported version of Python.

Tested locally:

<img width="379" alt="image" src="https://github.com/user-attachments/assets/51c2a1e7-ad02-4d0b-a93b-0b2cbb9a9c41">
