### PR TITLE
fix(#167): Separate "messages" from "logging"

### DIFF
--- a/src/twyn/base/exceptions.py
+++ b/src/twyn/base/exceptions.py
@@ -1,5 +1,17 @@
-class TwynError(Exception):
+import logging
+from typing import IO, Any, Optional
+
+import click
+
+logger = logging.getLogger("twyn.errors")
+
+
+class TwynError(click.ClickException):
     message = ""
 
     def __init__(self, message: str = "") -> None:
         super().__init__(message or self.message)
+
+    def show(self, file: Optional[IO[Any]] = None) -> None:
+        logger.debug(self.format_message(), exc_info=True)
+        logger.error(self.format_message(), exc_info=False)

--- a/src/twyn/cli.py
+++ b/src/twyn/cli.py
@@ -65,7 +65,9 @@ def run(
     vv: bool,
 ) -> int:
     if v and vv:
-        raise ValueError("Only one verbosity level is allowed. Choose either -v or -vv.")
+        raise click.UsageError(
+            "Only one verbosity level is allowed. Choose either -v or -vv.", ctx=click.get_current_context()
+        )
 
     if v:
         verbosity = AvailableLoggingLevels.info
@@ -75,10 +77,12 @@ def run(
         verbosity = AvailableLoggingLevels.none
 
     if dependency and dependency_file:
-        raise ValueError("Only one of --dependency or --dependency-file can be set at a time.")
+        raise click.UsageError(
+            "Only one of --dependency or --dependency-file can be set at a time.", ctx=click.get_current_context()
+        )
 
     if dependency_file and not any(dependency_file.endswith(key) for key in DEPENDENCY_FILE_MAPPING):
-        raise ValueError("Dependency file name not supported.")
+        raise click.UsageError("Dependency file name not supported.", ctx=click.get_current_context())
 
     return int(
         check_dependencies(

--- a/src/twyn/config/config_handler.py
+++ b/src/twyn/config/config_handler.py
@@ -19,7 +19,7 @@ from twyn.config.exceptions import (
     TOMLError,
 )
 
-logger = logging.getLogger()
+logger = logging.getLogger("twyn")
 
 
 @dataclass(frozen=True)

--- a/src/twyn/dependency_parser/abstract_parser.py
+++ b/src/twyn/dependency_parser/abstract_parser.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from twyn.file_handler.file_handler import FileHandlerPathlib
 
-logger = logging.getLogger()
+logger = logging.getLogger("twyn")
 
 
 class AbstractParser(ABC):

--- a/src/twyn/dependency_parser/dependency_selector.py
+++ b/src/twyn/dependency_parser/dependency_selector.py
@@ -8,7 +8,7 @@ from twyn.dependency_parser.exceptions import (
     NoMatchingParserError,
 )
 
-logger = logging.getLogger()
+logger = logging.getLogger("twyn")
 
 
 class DependencySelector:

--- a/src/twyn/file_handler/file_handler.py
+++ b/src/twyn/file_handler/file_handler.py
@@ -6,7 +6,7 @@ from typing import Protocol
 from twyn.base.exceptions import TwynError
 from twyn.file_handler.exceptions import PathIsNotFileError, PathNotFoundError
 
-logger = logging.getLogger()
+logger = logging.getLogger("twyn")
 
 
 class BaseFileHandler(Protocol):

--- a/src/twyn/main.py
+++ b/src/twyn/main.py
@@ -2,6 +2,7 @@ import logging
 import re
 from typing import Optional
 
+import click
 from rich.logging import RichHandler
 from rich.progress import track
 
@@ -24,7 +25,7 @@ logging.basicConfig(
     datefmt="[%X]",
     handlers=[RichHandler(rich_tracebacks=True, show_path=False)],
 )
-logger = logging.getLogger()
+logger = logging.getLogger("twyn")
 
 
 def check_dependencies(
@@ -61,10 +62,14 @@ def check_dependencies(
             errors.append(typosquat_results)
 
     for possible_typosquats in errors:
-        logger.error(
-            f"Possible typosquat detected: `{possible_typosquats.candidate_dependency}`, "
-            f"did you mean any of [{', '.join(possible_typosquats.similar_dependencies)}]?"
+        click.echo(
+            click.style("Possible typosquat detected: ", fg="red") + f"`{possible_typosquats.candidate_dependency}`, "
+            f"did you mean any of [{', '.join(possible_typosquats.similar_dependencies)}]?",
+            color=True,
         )
+
+    if not errors:
+        click.echo(click.style("No typosquats detected", fg="green"), color=True)
 
     return bool(errors)
 

--- a/src/twyn/similarity/algorithm.py
+++ b/src/twyn/similarity/algorithm.py
@@ -7,7 +7,7 @@ from rapidfuzz.distance import DamerauLevenshtein
 
 from twyn.similarity.exceptions import DistanceAlgorithmError, ThresholdError
 
-logger = logging.getLogger()
+logger = logging.getLogger("twyn")
 
 
 class SimilarityThreshold:
@@ -30,9 +30,7 @@ class SimilarityThreshold:
             logger.debug(f"max length of {cls.MAX_FOR_SHORT_WORDS} selected for {name}")
             return cls(max=cls.MAX_FOR_SHORT_WORDS)
         logger.debug(f"max length of {cls.MAX_FOR_LONG_WORDS} selected for {name}")
-        return cls(
-            max=cls.MAX_FOR_LONG_WORDS
-        )  # we allow more typos if the name is longer
+        return cls(max=cls.MAX_FOR_LONG_WORDS)  # we allow more typos if the name is longer
 
     def is_inside_threshold(self, value: float) -> bool:
         return self.min <= value <= self.max

--- a/src/twyn/trusted_packages/references.py
+++ b/src/twyn/trusted_packages/references.py
@@ -10,7 +10,7 @@ from twyn.trusted_packages.exceptions import (
     InvalidPyPiFormatError,
 )
 
-logger = logging.getLogger()
+logger = logging.getLogger("twyn")
 
 
 class AbstractPackageReference(ABC):

--- a/src/twyn/trusted_packages/selectors.py
+++ b/src/twyn/trusted_packages/selectors.py
@@ -10,7 +10,7 @@ from twyn.trusted_packages.exceptions import CharacterNotInMatrixError
 if TYPE_CHECKING:
     from twyn.trusted_packages.trusted_packages import _PackageNames
 
-logger = logging.getLogger()
+logger = logging.getLogger("twyn")
 
 
 class AbstractSelector(ABC):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,15 @@ import os
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
+from unittest import mock
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def disable_click_echo():
+    with mock.patch("click.echo"):
+        yield
 
 
 @contextmanager

--- a/tests/main/test_cli.py
+++ b/tests/main/test_cli.py
@@ -1,6 +1,5 @@
 from unittest.mock import call, patch
 
-import pytest
 from click.testing import CliRunner
 from twyn import cli
 from twyn.base.constants import AvailableLoggingLevels
@@ -97,12 +96,11 @@ class TestCli:
     def test_click_raises_error_dependency_and_dependency_file_set(self):
         runner = CliRunner()
         result = runner.invoke(
-            cli.run,
-            ["--dependency", "requests", "--dependency-file", "requirements.txt"],
+            cli.run, ["--dependency", "requests", "--dependency-file", "requirements.txt"], catch_exceptions=False
         )
-        with pytest.raises(ValueError, match="Only one of --dependency or --dependency-file can be set at a time."):
-            raise result.exception
-        assert result.exit_code == 1
+        assert isinstance(result.exception, SystemExit)
+        assert result.exit_code == 2
+        assert "Only one of --dependency or --dependency-file can be set at a time." in result.output
 
     @patch("twyn.cli.check_dependencies")
     def test_click_arguments_multiple_dependencies_cli(self, mock_check_dependencies):
@@ -144,16 +142,16 @@ class TestCli:
 
     def test_only_one_verbosity_level_is_allowed(self):
         runner = CliRunner()
-        with pytest.raises(
-            ValueError,
-            match="Only one verbosity level is allowed. Choose either -v or -vv.",
-        ):
-            runner.invoke(cli.run, ["-v", "-vv"], catch_exceptions=False)
+        result = runner.invoke(cli.run, ["-v", "-vv"], catch_exceptions=False)
+
+        assert isinstance(result.exception, SystemExit)
+        assert result.exit_code == 2
+        assert "Only one verbosity level is allowed. Choose either -v or -vv." in result.output
 
     def test_dependency_file_name_has_to_be_recognized(self):
         runner = CliRunner()
-        with pytest.raises(
-            ValueError,
-            match="Dependency file name not supported.",
-        ):
-            runner.invoke(cli.run, ["--dependency-file", "requirements-dev.txt"], catch_exceptions=False)
+        result = runner.invoke(cli.run, ["--dependency-file", "requirements-dev.txt"], catch_exceptions=False)
+
+        assert isinstance(result.exception, SystemExit)
+        assert result.exit_code == 2
+        assert "Dependency file name not supported." in result.output


### PR DESCRIPTION
We were mixing two different concepts:
- `logging` are messages about what twyn is doing, etc. Using the logging module.
- `messages` are direct prints to the terminal by the cli

I changed it to be separated:
- The final "Typosquat detected" is now a `click` message. Not an "error" (it's not an _error_, the tool worked correctly!)
- Added a new "no typosquats detected", in green.
- Made the loggers named.
- Made all exceptions inherit from `ClickException`, as the click docs suggest.
- Made `TwynError` display tracebacks only on debug mode.

Examples:

- Typosquat detected
<img width="710" alt="image" src="https://github.com/user-attachments/assets/e71d1d47-da67-402e-b88e-184974dfdced">

- No typosquat detected
<img width="589" alt="image" src="https://github.com/user-attachments/assets/2cd5ad85-7f9a-4fa0-9d90-ac6fa1652284">

- An error (an exception) raised with no "DEBUG" flag
<img width="582" alt="image" src="https://github.com/user-attachments/assets/027a5e18-5828-4e44-ac70-bcce3515ba24">

- An error (an exception) raised with "DEBUG" flag
<img width="837" alt="image" src="https://github.com/user-attachments/assets/c39342ee-e1c6-4921-917f-55be9c4614ef">

(as you can see in the last image, one nice perk of this is that we are taking advantage of `rich` exception beautifying capabilities 😄 )


closes #167 