### PR TITLE
chore: Use FileHandlerPathlib in ConfigHandler

### DIFF
--- a/src/twyn/cli.py
+++ b/src/twyn/cli.py
@@ -5,11 +5,13 @@ import click
 
 from twyn.__version__ import __version__
 from twyn.base.constants import (
+    DEFAULT_PROJECT_TOML_FILE,
     DEPENDENCY_FILE_MAPPING,
     SELECTOR_METHOD_MAPPING,
     AvailableLoggingLevels,
 )
 from twyn.config.config_handler import ConfigHandler
+from twyn.file_handler.file_handler import FileHandler
 from twyn.main import check_dependencies
 
 
@@ -101,15 +103,19 @@ def allowlist() -> None:
 
 
 @allowlist.command()
+@click.option("--config", type=click.STRING)
 @click.argument("package_name")
-def add(package_name: str) -> None:
-    ConfigHandler().add_package_to_allowlist(package_name)
+def add(package_name: str, config: str) -> None:
+    fh = FileHandler(config or DEFAULT_PROJECT_TOML_FILE)
+    ConfigHandler(fh).add_package_to_allowlist(package_name)
 
 
 @allowlist.command()
+@click.option("--config", type=click.STRING)
 @click.argument("package_name")
-def remove(package_name: str) -> None:
-    ConfigHandler().remove_package_from_allowlist(package_name)
+def remove(package_name: str, config: str) -> None:
+    fh = FileHandler(config or DEFAULT_PROJECT_TOML_FILE)
+    ConfigHandler(fh).remove_package_from_allowlist(package_name)
 
 
 if __name__ == "__main__":

--- a/src/twyn/dependency_parser/abstract_parser.py
+++ b/src/twyn/dependency_parser/abstract_parser.py
@@ -3,7 +3,7 @@ import os
 from abc import ABC, abstractmethod
 from pathlib import Path
 
-from twyn.file_handler.file_handler import FileHandlerPathlib
+from twyn.file_handler.file_handler import FileHandler
 
 logger = logging.getLogger("twyn")
 
@@ -17,7 +17,7 @@ class AbstractParser(ABC):
 
     def __init__(self, file_path: str) -> None:
         self.file_path = Path(os.path.abspath(os.path.join(os.getcwd(), file_path)))
-        self.file_handler = FileHandlerPathlib(file_path=self.file_path)
+        self.file_handler = FileHandler(file_path=self.file_path)
 
     def __str__(self) -> str:
         return self.__class__.__name__

--- a/src/twyn/file_handler/file_handler.py
+++ b/src/twyn/file_handler/file_handler.py
@@ -10,14 +10,20 @@ logger = logging.getLogger("twyn")
 
 
 class BaseFileHandler(Protocol):
-    def __init__(self, file_path: str) -> None: ...
     def read(self) -> str: ...
     def file_exists(self) -> bool: ...
+    def write(self, data: str) -> None: ...
 
 
-class FileHandlerPathlib(BaseFileHandler):
+class FileHandler(BaseFileHandler):
     def __init__(self, file_path: str) -> None:
-        self.file_path = Path(os.path.abspath(os.path.join(os.getcwd(), file_path)))
+        self.file_path = self._get_file_path(file_path)
+
+    def _get_file_path(self, file_path: str) -> Path:
+        return Path(os.path.abspath(os.path.join(os.getcwd(), file_path)))
+
+    def is_handler_of_file(self, name: str) -> bool:
+        return self._get_file_path(name) == self.file_path
 
     def read(self) -> str:
         self._raise_for_file_exists()
@@ -40,3 +46,7 @@ class FileHandlerPathlib(BaseFileHandler):
 
         if not self.file_path.is_file():
             raise PathIsNotFileError
+
+    def write(self, data: str) -> None:
+        self._raise_for_file_exists()
+        self.file_path.write_text(data)

--- a/src/twyn/main.py
+++ b/src/twyn/main.py
@@ -7,11 +7,13 @@ from rich.logging import RichHandler
 from rich.progress import track
 
 from twyn.base.constants import (
+    DEFAULT_PROJECT_TOML_FILE,
     SELECTOR_METHOD_MAPPING,
     AvailableLoggingLevels,
 )
 from twyn.config.config_handler import ConfigHandler
 from twyn.dependency_parser.dependency_selector import DependencySelector
+from twyn.file_handler.file_handler import FileHandler
 from twyn.similarity.algorithm import EditDistance, SimilarityThreshold
 from twyn.trusted_packages import TopPyPiReference
 from twyn.trusted_packages.selectors import AbstractSelector
@@ -36,7 +38,8 @@ def check_dependencies(
     verbosity: AvailableLoggingLevels = AvailableLoggingLevels.none,
 ) -> bool:
     """Check if dependencies could be typosquats."""
-    config = ConfigHandler(file_path=config_file, enforce_file=False).resolve_config(
+    config_file_handler = FileHandler(config_file or DEFAULT_PROJECT_TOML_FILE)
+    config = ConfigHandler(config_file_handler, enforce_file=False).resolve_config(
         verbosity=verbosity, selector_method=selector_method, dependency_file=dependency_file
     )
     _set_logging_level(config.logging_level)

--- a/tests/file_handler/test_file_handler.py
+++ b/tests/file_handler/test_file_handler.py
@@ -2,16 +2,16 @@ from unittest.mock import patch
 
 import pytest
 from twyn.file_handler.exceptions import PathIsNotFileError, PathNotFoundError
-from twyn.file_handler.file_handler import FileHandlerPathlib
+from twyn.file_handler.file_handler import FileHandler
 
 
-class TestFileHandlerPathlib:
+class TestFileHandler:
     def test_file_exists(self, pyproject_toml_file: str):
-        parser = FileHandlerPathlib(pyproject_toml_file)
+        parser = FileHandler(pyproject_toml_file)
         assert parser.file_exists() is True
 
     def test_read_file_success(self, pyproject_toml_file: str):
-        parser = FileHandlerPathlib(pyproject_toml_file)
+        parser = FileHandler(pyproject_toml_file)
         read = parser.read()
         assert len(read) > 1
         assert isinstance(read, str)
@@ -19,7 +19,7 @@ class TestFileHandlerPathlib:
     def test_read_file_does_not_exist(
         self,
     ):
-        parser = FileHandlerPathlib("")
+        parser = FileHandler("")
         with pytest.raises(PathIsNotFileError):
             parser.read()
 
@@ -33,5 +33,5 @@ class TestFileHandlerPathlib:
         mock_exists.return_value = file_exists
         mock_is_file.return_value = is_file
 
-        parser = FileHandlerPathlib("fake.txt")
+        parser = FileHandler("fake.txt")
         assert parser.file_exists() is False

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -5,6 +5,7 @@ from tomlkit import dumps, parse
 from twyn.base.constants import DEFAULT_TOP_PYPI_PACKAGES, AvailableLoggingLevels
 from twyn.config.config_handler import ConfigHandler, TwynConfiguration, _get_logging_level
 from twyn.dependency_parser import RequirementsTxtParser
+from twyn.file_handler.file_handler import FileHandler
 from twyn.main import (
     check_dependencies,
     get_parsed_dependencies_from_file,
@@ -104,7 +105,7 @@ class TestCheckDependencies:
         3. default values
 
         """
-        handler = ConfigHandler(file_path=None, enforce_file=False)
+        handler = ConfigHandler(FileHandler(""), enforce_file=False)
 
         with patch.object(handler, "_read_toml", return_value=parse(dumps({"tool": {"twyn": file_config}}))):
             resolved = handler.resolve_config(


### PR DESCRIPTION
Integrate FileHandlerPathlib in ConfigHandler class.

That will make the file handler be the only one interacting with read/writes to disk. It can be seen as an additional layer, where some other parts of Twyn are built on.

This is another PR for #143.