### PR TITLE
ci: Trigger release notes job after publishing has succeeded

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,16 +11,6 @@ permissions:
   contents: write
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          token: "${{ secrets.GITHUB_TOKEN }}"
-
   push_to_pypi:
     runs-on: ubuntu-latest
     steps:
@@ -59,3 +49,13 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+  release_notes:
+    runs-on: ubuntu-latest
+    needs: push_to_docker_hub
+    steps:
+      - uses: actions/checkout@v4
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          token: "${{ secrets.GITHUB_TOKEN }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "twyn"
-version = "2.8.11"
+version = "2.8.12"
 description = ""
 authors = [
     "Daniel Sanz",


### PR DESCRIPTION
Release notes are created at the moment we publish tags. However, the fact that we could publish them does not mean that the `bump_version` job was successful, like in [this case](https://github.com/elementsinteractive/twyn/actions/runs/13197400016/job/36841617955), due to a misconfiguration of the rulesets. 

An easy way to solve the issue above would be: 1)fix the rulesets 2) delete tags 3) rerun `bump_version` job. That's not currently possible, because in order to delete the tags we would need to first delete the release notes, and even if we did this, the job that publishes the release notes will be called twice.

This PR ensures that we only publish the release notes if all the other jobs have succeeded, to avoid unexpected consequences.