### PR TITLE
fix: pin osv's version to 1.9.2

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,7 +12,7 @@ jobs:
   osv-scanner:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/google/osv-scanner:latest
+      image: ghcr.io/google/osv-scanner:v1.9.2
     steps:
       - uses: actions/checkout@v3
       - name: Run OSV Scanner


### PR DESCRIPTION
Right now it's pinned to `latest`. This is a problem as there's a breaking change in their newest image `v2.0.0-beta`.

I'm pinning the version in our workflow, and once there's an official `v2` we can move towards using it.