### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/src/twyn/base/constants.py
+++ b/src/twyn/base/constants.py
@@ -24,7 +24,7 @@ DEPENDENCY_FILE_MAPPING: dict[str, type[AbstractParser]] = {
 DEFAULT_SELECTOR_METHOD = "all"
 DEFAULT_DEPENDENCY_FILE = "requirements.txt"
 DEFAULT_PROJECT_TOML_FILE = "pyproject.toml"
-DEFAULT_TOP_PYPI_PACKAGES = "https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json"
+DEFAULT_TOP_PYPI_PACKAGES = "https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json"
 
 
 class AvailableLoggingLevels(enum.Enum):


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.