### PR TITLE
ci: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,3 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "pip"
@@ -12,9 +7,17 @@ updates:
       day: "monday"
     labels:
       - "dependencies"
+      - "ignore-for-release"
     commit-message:
       prefix: "chore"
     groups:
-      dependencies:
+      patch-updates:
         patterns:
           - "*"
+        update-types:
+          - "patch"
+      minor-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"


### PR DESCRIPTION
`minor` and `patch` updates will be grouped in their own PRs, and we will have a PR for every major update.

This will allow us to:

- Isolate major changes.
- Be able to auto-merge `minor` and `patch`, because right now all dependencies go in the same PR and it can happen that a `major` update blocks the rest (we only trigger auto-merge if it's a non-major update).