### PR TITLE
fix: dynamic versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,25 @@ dependencies = [
     "tomli<3.0.0,>=2.2.1; python_version < \"3.13\"",
 ]
 name = "twyn"
-version = "2.9.0"
-description = ""
+description = "Security tool against dependency typosquatting attacks"
 readme = "README.md"
+dynamic = ["version"]
+
+[tool.hatch.version]
+path = "VERSION"
+pattern = "v(?P<version>[^\\s]+)"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/twyn"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src",
+    "/README.md",
+    "/LICENSE",
+    "/VERSION",
+    "/pyproject.toml",
+]
 
 [project.scripts]
 twyn = "twyn.cli:entry_point"

--- a/uv.lock
+++ b/uv.lock
@@ -1149,7 +1149,6 @@ wheels = [
 
 [[package]]
 name = "twyn"
-version = "2.8.28"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Because we did not have dynamic versioning, after increasing `twyn` version, there was a mismatch between the uv.lock (containing old non-updated version) and pyproject.toml (updated version) files.

This resulted in not being able to install the package without running `uv.lock`. This PR fixes it.