### PR TITLE
ci: Create action for docker builds

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -1,0 +1,63 @@
+# Action that wraps together all the necessary actions to build an image and publish it.
+# It does not include login actions.
+# This is a convenience, so that we know that everything related to the build lies in this file,
+# and if it gets updated we can automatically run our `test-docker-build` from `build-test.yml.`
+
+name: "Docker Build"
+description: "Builds Docker images with optional caching and multi-platform support"
+
+inputs:
+  push-image:
+    description: "Whether to push the built image"
+    required: false
+    default: "false"
+  platforms:
+    description: "Target platforms for the build"
+    required: false
+    default: "linux/amd64"
+  dockerfile:
+    description: "Path to the Dockerfile"
+    required: false
+    default: "./Dockerfile"
+  context:
+    description: "Build context path"
+    required: false
+    default: "."
+  image-name:
+    description: "Docker image name"
+    required: true
+  cache-from:
+    description: "Cache source for Docker build"
+    required: false
+    default: ""
+  cache-to:
+    description: "Cache destination for Docker build"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
+      with:
+        images: ${{ inputs['image-name'] }}
+
+    - name: Build Docker image
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.dockerfile }}
+        push: ${{ inputs['push-image'] }}
+        platforms: ${{ inputs.platforms }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: ${{ inputs['cache-from'] }}
+        cache-to: ${{ inputs['cache-to'] }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,7 +7,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-
+  
 jobs:
   test-build-package:
     name: Test package build
@@ -53,20 +53,23 @@ jobs:
 
       - name: Check if Dockerfile changed
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: dockerfile-changes
+        id: docker-changes
         with:
           filters: |
-            dockerfile:
+            docker:
               - 'Dockerfile'
               - '.dockerignore'
+            workflow:
+              - ./.github/actions/docker-build/action.yml
     outputs:
-      docker: ${{ steps.dockerfile-changes.outputs.dockerfile }}
+      docker: ${{ steps.docker-changes.outputs.docker }}
+      workflow: ${{ steps.docker-changes.outputs.workflow }}
 
   test-docker-build:
     needs: [should-test-docker-build]
     name: Test Docker build
     runs-on: ubuntu-latest
-    if: needs.should-test-docker-build.outputs.docker == 'true' && !startsWith(github.event.head_commit.message, 'bump:')
+    if: ((needs.should-test-docker-build.outputs.workflow == 'true' && ${{ github.actor == 'dependabot[bot]' }} ) || needs.should-test-docker-build.outputs.docker == 'true') && !startsWith(github.event.head_commit.message, 'bump:')
     permissions:
       contents: read
       packages: read
@@ -81,22 +84,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
-        with:
-          images: elementsinteractive/twyn
-
-      - name: Build Docker image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+      - name: Build image
+        uses: ./.github/actions/docker-build
         with:
           context: .
           file: ./Dockerfile
           push: false
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=ghcr.io/elementsinteractive/twyn:buildcache
+       

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-
       - name: Log in to Docker Hub
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
@@ -53,25 +50,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
-        with:
-          images: elementsinteractive/twyn
-
       - name: Build and push Docker image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        uses: ./.github/actions/docker-build
         with:
-          context: .
-          file: ./Dockerfile
-          push: true
+          push-image: "true"
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: |
-            type=registry,ref=ghcr.io/elementsinteractive/twyn:buildcache
-          cache-to: |
-            type=registry,ref=ghcr.io/elementsinteractive/twyn:buildcache,mode=max,compression=zstd,force-compression=true,oci-mediatypes=true
+          dockerfile: ./Dockerfile
+          context: .
+          image-name: elementsinteractive/twyn
+          cache-from: type=registry,ref=ghcr.io/elementsinteractive/twyn:buildcache
+          cache-to: type=registry,ref=ghcr.io/elementsinteractive/twyn:buildcache,mode=max,compression=zstd,force-compression=true,oci-mediatypes=true
+
       - name: Delete old cache entries
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This PR centralices all the needed actions to build and push the docker image. 

This is a convenience, so that we know that everything related to the build lies in this file, and if it gets updated (i.e because of a dependabot update) it will automatically run our `test-docker-build` from `build-test.yml.`