### PR TITLE
feat: save downloaded packages to cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.pyc
 __pycache__
 db.sqlite3
-
+.twyn/
 # Backup files #
 *.bak
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,15 +49,17 @@ dev = [
     "pytest<9.0.0,>=7.1.3",
     "mypy<1.17,>=0.982",
     "pytest-cov<7,>=4",
-
     "ruff<0.12.4,>=0.5.1",
     "types-requests<3.0.0.0,>=2.32.4.20250611",
+    "types-python-dateutil>=2.9.0.20250809",
+     "freezegun>=1.5.5",
 ]
 local = [
     "ipdb<1.0.0,>=0.13.9",
     "commitizen<5.0,>=2.38",
     "pdbpp<1.0.0,>=0.11.6",
 ]
+
 
 [build-system]
 requires = ["hatchling"]

--- a/src/twyn/base/utils.py
+++ b/src/twyn/base/utils.py
@@ -1,0 +1,6 @@
+import re
+
+
+def _normalize_packages(packages: set[str]) -> set[str]:
+    """Normalize dependency names according to PyPi https://packaging.python.org/en/latest/specifications/name-normalization/."""
+    return {re.sub(r"[-_.]+", "-", name).lower() for name in packages}

--- a/src/twyn/cli.py
+++ b/src/twyn/cli.py
@@ -58,6 +58,12 @@ def entry_point() -> None:
     default=False,
     is_flag=True,
 )
+@click.option(
+    "--no-cache",
+    is_flag=True,
+    default=False,
+    help="Disable use of the trusted packages cache. Always fetch from the source.",
+)
 def run(
     config: str,
     dependency_file: Optional[str],
@@ -65,6 +71,7 @@ def run(
     selector_method: str,
     v: bool,
     vv: bool,
+    no_cache: bool,
 ) -> int:
     if v and vv:
         raise click.UsageError(
@@ -92,6 +99,7 @@ def run(
         dependency_file=dependency_file,
         selector_method=selector_method,
         verbosity=verbosity,
+        use_cache=not no_cache,
     )
 
     if errors:

--- a/src/twyn/dependency_parser/abstract_parser.py
+++ b/src/twyn/dependency_parser/abstract_parser.py
@@ -26,7 +26,7 @@ class AbstractParser(ABC):
         return self.file_handler.read()
 
     def file_exists(self) -> bool:
-        return self.file_handler.file_exists()
+        return self.file_handler.exists()
 
     @abstractmethod
     def parse(self) -> set[str]:

--- a/src/twyn/file_handler/file_handler.py
+++ b/src/twyn/file_handler/file_handler.py
@@ -11,7 +11,7 @@ logger = logging.getLogger("twyn")
 
 class BaseFileHandler(Protocol):
     def read(self) -> str: ...
-    def file_exists(self) -> bool: ...
+    def exists(self) -> bool: ...
     def write(self, data: str) -> None: ...
 
 
@@ -33,7 +33,7 @@ class FileHandler(BaseFileHandler):
 
         return content
 
-    def file_exists(self) -> bool:
+    def exists(self) -> bool:
         try:
             self._raise_for_file_exists()
         except TwynError:
@@ -48,5 +48,4 @@ class FileHandler(BaseFileHandler):
             raise PathIsNotFileError
 
     def write(self, data: str) -> None:
-        self._raise_for_file_exists()
         self.file_path.write_text(data)

--- a/src/twyn/trusted_packages/constants.py
+++ b/src/twyn/trusted_packages/constants.py
@@ -1,3 +1,8 @@
+# Cache configuration constants
+TRUSTED_PACKAGES_FILE_PATH = ".twyn/trusted_packages.json"
+TRUSTED_PACKAGES_MAX_RETENTION_DAYS = 30
+
+
 ADJACENCY_MATRIX = {
     "1": ["2", "q", "w"],
     "2": ["1", "3", "q", "w"],

--- a/src/twyn/trusted_packages/exceptions.py
+++ b/src/twyn/trusted_packages/exceptions.py
@@ -13,4 +13,8 @@ class EmptyPackagesListError(TwynError):
     message = "Downloaded packages list is empty"
 
 
-class CharacterNotInMatrixError(TwynError, KeyError): ...
+class CharacterNotInMatrixError(TwynError, KeyError): ...  # TODO add comments
+
+
+class InvalidCacheError(TwynError):
+    """Error for when the cache content is not valid."""

--- a/src/twyn/trusted_packages/references.py
+++ b/src/twyn/trusted_packages/references.py
@@ -1,11 +1,17 @@
+import json
 import logging
 from abc import ABC, abstractmethod
+from datetime import date, datetime
 from typing import Any
 
 import requests
 
+from twyn.base.utils import _normalize_packages
+from twyn.file_handler.file_handler import FileHandler
+from twyn.trusted_packages.constants import TRUSTED_PACKAGES_FILE_PATH, TRUSTED_PACKAGES_MAX_RETENTION_DAYS
 from twyn.trusted_packages.exceptions import (
     EmptyPackagesListError,
+    InvalidCacheError,
     InvalidJSONError,
     InvalidPyPiFormatError,
 )
@@ -20,17 +26,95 @@ class AbstractPackageReference(ABC):
         self.source = source
 
     @abstractmethod
-    def get_packages(self) -> set[str]:
+    def get_packages(self, use_cache: bool = True) -> set[str]:
         """Return the names of the trusted packages available in the reference."""
 
 
 class TopPyPiReference(AbstractPackageReference):
     """Top PyPi packages retrieved from an online source."""
 
-    def get_packages(self) -> set[str]:
+    def get_packages(self, use_cache: bool = True) -> set[str]:
         """Download and parse online source of top Python Package Index packages."""
-        packages_info = self._download()
-        return self._parse(packages_info)
+        packages_to_use = set()
+        if use_cache:
+            trusted_packages_file = FileHandler(TRUSTED_PACKAGES_FILE_PATH)
+            packages_to_use = self._get_packages_from_cache(trusted_packages_file)
+            # we don't save the cache here, we keep it as it is so the date remains the original one.
+
+        if not packages_to_use:
+            # no cache usage, no cache hit (non-existent or outdated) or cache was empty.
+            logger.info("Fetching trusted packages from PyPI reference...")
+            packages_to_use = self._parse(self._download())
+            if use_cache:
+                self._save_trusted_packages_to_file(packages_to_use, trusted_packages_file, self.source)
+
+        normalized_packages = _normalize_packages(packages_to_use)
+        return normalized_packages
+
+    def _is_content_outdated(self, content_date: date) -> bool:
+        """Check if cached content is outdated based on retention days."""
+        days_diff = (datetime.today().date() - content_date).days
+        return days_diff > TRUSTED_PACKAGES_MAX_RETENTION_DAYS
+
+    def _save_trusted_packages_to_file(self, packages: set[str], file_handler: FileHandler, source: str) -> None:
+        """Save trusted packages to JSON file with timestamp."""
+        trusted_data = {
+            "source": source,
+            "data": {
+                "packages": list(packages),
+                "count": len(packages),
+                "saved_date": datetime.now().date().isoformat(),
+            },
+        }
+        file_handler.file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_handler.write(json.dumps(trusted_data))
+        logger.debug("Saved %d trusted packages to %s", len(packages), file_handler.file_path)
+
+    def _load_trusted_packages_from_file(self, file_handler: FileHandler) -> tuple[set[str], bool]:
+        """Load trusted packages from JSON file and check if it's outdated."""
+        try:
+            try:
+                trusted_packages_raw_content = json.loads(file_handler.read())
+            except json.JSONDecodeError as e:
+                raise InvalidCacheError("Could not decode cache.") from e
+
+            try:
+                data = trusted_packages_raw_content["data"]
+                saved_date_str = data["saved_date"]
+            except KeyError as e:
+                raise InvalidCacheError("Invalid cache format.") from e
+
+            try:
+                saved_date = datetime.fromisoformat(saved_date_str).date()
+            except ValueError as e:
+                raise InvalidCacheError("Cache saved date is invalid.") from e
+
+            try:
+                packages = set(data["packages"])
+            except TypeError as e:
+                raise InvalidCacheError("Invalid format in cached packages") from e
+
+            is_outdated = self._is_content_outdated(saved_date)
+
+        except InvalidCacheError as e:
+            logger.warning("Error reading cached trusted packages: %s", e)
+            return set(), True
+        else:
+            if is_outdated:
+                logger.info("Cached trusted packages are outdated (saved: %s)", saved_date)
+            else:
+                logger.debug("Using cached trusted packages from %s", saved_date)
+
+            return packages, is_outdated
+
+    def _get_packages_from_cache(self, trusted_packages_file: FileHandler) -> set[str]:
+        """Get packages from cache file if it's present and up to date."""
+        if trusted_packages_file.exists():
+            packages_from_cache, is_outdated = self._load_trusted_packages_from_file(trusted_packages_file)
+            if not is_outdated:
+                return packages_from_cache
+
+        return set()
 
     def _download(self) -> dict[str, Any]:
         packages = requests.get(self.source)

--- a/tests/file_handler/test_file_handler.py
+++ b/tests/file_handler/test_file_handler.py
@@ -8,7 +8,7 @@ from twyn.file_handler.file_handler import FileHandler
 class TestFileHandler:
     def test_file_exists(self, pyproject_toml_file: str):
         parser = FileHandler(pyproject_toml_file)
-        assert parser.file_exists() is True
+        assert parser.exists() is True
 
     def test_read_file_success(self, pyproject_toml_file: str):
         parser = FileHandler(pyproject_toml_file)
@@ -34,4 +34,4 @@ class TestFileHandler:
         mock_is_file.return_value = is_file
 
         parser = FileHandler("fake.txt")
-        assert parser.file_exists() is False
+        assert parser.exists() is False

--- a/tests/main/conftest.py
+++ b/tests/main/conftest.py
@@ -1,10 +1,12 @@
+from collections.abc import Generator
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 
 
 @pytest.fixture(scope="module")
-def disable_track():
+def disable_track() -> Generator[None, Any, None]:
     """Disables the track UI for running tests."""
     with patch("twyn.main.track") as m_track:
         m_track.side_effect = lambda iterable, description: iterable

--- a/tests/main/test_cli.py
+++ b/tests/main/test_cli.py
@@ -7,6 +7,16 @@ from twyn.trusted_packages.trusted_packages import TyposquatCheckResult
 
 
 class TestCli:
+    @patch("twyn.cli.check_dependencies")
+    def test_no_cache_option_disables_cache(self, mock_check_dependencies):
+        runner = CliRunner()
+        runner.invoke(
+            cli.run,
+            ["--no-cache", "--dependency", "requests"],
+        )
+        assert mock_check_dependencies.call_args[1]["use_cache"] is False
+        assert mock_check_dependencies.call_args[1]["dependencies"] == {"requests"}
+
     @patch("twyn.config.config_handler.ConfigHandler.add_package_to_allowlist")
     def test_allowlist_add_package_to_allowlist(self, mock_allowlist_add):
         runner = CliRunner()
@@ -50,6 +60,7 @@ class TestCli:
                 dependencies=None,
                 selector_method="first-letter",
                 verbosity=AvailableLoggingLevels.debug,
+                use_cache=True,
             )
         ]
 
@@ -71,6 +82,7 @@ class TestCli:
                 dependencies=None,
                 selector_method=None,
                 verbosity=AvailableLoggingLevels.none,
+                use_cache=True,
             )
         ]
 
@@ -91,6 +103,7 @@ class TestCli:
                 dependencies={"reqests"},
                 selector_method=None,
                 verbosity=AvailableLoggingLevels.none,
+                use_cache=True,
             )
         ]
 
@@ -123,6 +136,7 @@ class TestCli:
                 dependencies={"reqests", "reqeusts"},
                 selector_method=None,
                 verbosity=AvailableLoggingLevels.none,
+                use_cache=True,
             )
         ]
 
@@ -138,6 +152,7 @@ class TestCli:
                 selector_method=None,
                 dependencies=None,
                 verbosity=AvailableLoggingLevels.none,
+                use_cache=True,
             )
         ]
 

--- a/tests/trusted_packages/test_references.py
+++ b/tests/trusted_packages/test_references.py
@@ -1,7 +1,13 @@
-from unittest.mock import call, patch
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock, patch
 
 import pytest
 import requests
+from freezegun import freeze_time
+from twyn.base.constants import DEFAULT_TOP_PYPI_PACKAGES
 from twyn.trusted_packages import TopPyPiReference
 from twyn.trusted_packages.exceptions import (
     EmptyPackagesListError,
@@ -10,26 +16,63 @@ from twyn.trusted_packages.exceptions import (
 )
 from twyn.trusted_packages.references import AbstractPackageReference
 
-from tests.conftest import patch_pypi_requests_get
+from tests.conftest import patch_pypi_packages_download
+
+
+class DummyFileHandler:
+    def __init__(self, content: Any) -> None:
+        self._content = content
+
+    def read(self):
+        return self._content
 
 
 class TestAbstractPackageReference:
-    class HardcodedPackageReference(AbstractPackageReference):
+    class DummyPackageReference(AbstractPackageReference):
         """Returns always the same packages, used for testing the interface."""
 
         def get_packages(self) -> set[str]:
             return {"foo", "bar"}
 
-    def test_get_packages(self):
-        assert self.HardcodedPackageReference(source="foo").get_packages() == {"foo", "bar"}
+    def test_get_packages(self) -> None:
+        assert self.DummyPackageReference(source="foo").get_packages() == {"foo", "bar"}
 
 
 class TestTopPyPiReference:
-    @patch_pypi_requests_get(packages=["boto3", "urllib3", "requests"])
-    def test_get_trusted_packages(self):
-        top_pypi = TopPyPiReference(source="foo")
+    @freeze_time("2025-8-21", tz_offset=0)
+    def test_cache_is_saved_when_not_existing(self, tmp_cache_file: Path) -> None:
+        """Test that cache starts empty and gets filled after downloading packages."""
+        # Verify cache file is initially empty
+        assert tmp_cache_file.exists() is False
 
-        assert top_pypi.get_packages() == {"boto3", "urllib3", "requests"}
+        cached_packages = {"numpy", "requests", "django"}
+
+        with patch_pypi_packages_download(cached_packages) as m_pypi:
+            pypi_ref = TopPyPiReference(source="https://test.pypi.org/simple")
+
+            retrieved_packages = pypi_ref.get_packages(use_cache=True)
+
+        # The packages were downloaded and match the expected result
+        assert m_pypi.call_count == 1
+        assert retrieved_packages == cached_packages
+
+        # The packages were saved to the cache file, with its associated metadata
+        cache_content = json.loads(tmp_cache_file.read_text())
+
+        assert cache_content["source"] == "https://test.pypi.org/simple"
+        assert set(cache_content["data"]["packages"]) == cached_packages
+        assert cache_content["data"]["count"] == len(cached_packages)
+        assert cache_content["data"]["saved_date"] == "2025-08-21"
+
+    def test_get_trusted_packages(self) -> None:
+        test_packages = ["foo", "bar", "django", "requests", "sqlalchemy"]
+
+        with patch_pypi_packages_download(test_packages) as m_pypi:
+            ref = TopPyPiReference(source=DEFAULT_TOP_PYPI_PACKAGES)
+            packages = ref.get_packages()
+
+        assert packages == {"foo", "bar", "django", "requests", "sqlalchemy"}
+        assert m_pypi.call_count == 1
 
     def test__parse_no_rows(self):
         data = {"bananas": 5}
@@ -38,7 +81,7 @@ class TestTopPyPiReference:
         with pytest.raises(InvalidPyPiFormatError, match="Invalid JSON format."):
             top_pypi._parse(data)
 
-    def test_empty_packages_list_exception(self):
+    def test_empty_packages_list_exception(self) -> None:
         with pytest.raises(
             EmptyPackagesListError,
             match="Downloaded packages list is empty",
@@ -51,17 +94,8 @@ class TestTopPyPiReference:
 
         assert top_pypi._parse(data) == {"boto3", "requests"}
 
-    @pytest.mark.parametrize("source", ["foo.com", "bar.com"])
-    def test_can_use_different_pypi_sources(self, source):
-        top_pypi = TopPyPiReference(source=source)
-
-        with patch_pypi_requests_get(packages=["foo"]) as mock_get:
-            top_pypi.get_packages()
-
-        assert mock_get.call_args_list == [call(source)]
-
     @patch("requests.get")
-    def test__download_json_exception(self, mock_get):
+    def test__download_json_exception(self, mock_get: Mock) -> None:
         mock_get.return_value.json.side_effect = requests.exceptions.JSONDecodeError(
             "This exception will be mapped and never shown", "", 1
         )
@@ -73,13 +107,103 @@ class TestTopPyPiReference:
         ):
             top_pypi._download()
 
-    @patch_pypi_requests_get(packages=["boto3", "requests"])
-    def test__download(self):
-        top_pypi = TopPyPiReference(source="foo")
+    @freeze_time("2025-8-19")
+    def test_get_trusted_packages_uses_valid_cache(self, tmp_cache_file: Path) -> None:
+        """Test that valid cached data is loaded and used without fetching from PyPI."""
+        packages = ["requests", "flask", "django", "fastapi"]
 
-        assert top_pypi._download() == {
-            "rows": [
-                {"project": "boto3"},
-                {"project": "requests"},
-            ]
+        cached_data = {
+            "source": DEFAULT_TOP_PYPI_PACKAGES,
+            "data": {
+                "packages": packages,
+                "count": 4,
+                "saved_date": "2025-08-19",  # yesterday
+            },
         }
+
+        tmp_cache_file.write_text(json.dumps(cached_data))
+        with patch_pypi_packages_download(packages) as m_pypi:
+            result = TopPyPiReference("").get_packages(use_cache=True)
+
+        assert m_pypi.call_count == 0
+        assert result == {"flask", "fastapi", "requests", "django"}
+
+    def test_get_packages_no_cache(self):
+        """Test that when use_cache is False, cache is not read or written, and packages are retrieved."""
+        test_packages = ["numpy", "requests", "django"]
+        source_url = "https://test.pypi.org/simple"
+
+        with (
+            patch.object(TopPyPiReference, "_get_packages_from_cache") as mock_get_cache,
+            patch.object(TopPyPiReference, "_save_trusted_packages_to_file") as mock_save_cache,
+            patch_pypi_packages_download(test_packages) as mock_pypi,
+        ):
+            ref = TopPyPiReference(source=source_url)
+            result = ref.get_packages(use_cache=False)
+
+        assert mock_get_cache.call_count == 0
+        assert mock_save_cache.call_count == 0
+        assert mock_pypi.call_count == 1
+        assert set(result) == set(test_packages)
+
+    def test_cache_valid_for_fractional_days(self, tmp_cache_file: Path) -> None:
+        """Test that cache is still loaded when age is 29.7 days (not outdated) and no download occurs."""
+        test_packages = ["numpy", "requests"]
+        now = datetime.now().astimezone()
+        saved_date = (now - timedelta(days=29, hours=16, minutes=48)).isoformat()  # 29.7 days ago
+
+        cache_data = {
+            "source": DEFAULT_TOP_PYPI_PACKAGES,
+            "data": {
+                "packages": test_packages,
+                "count": len(test_packages),
+                "saved_date": saved_date,
+            },
+        }
+        tmp_cache_file.write_text(json.dumps(cache_data))
+
+        with freeze_time(now), patch_pypi_packages_download(["should_not_be_used"]) as mock_download:
+            ref = TopPyPiReference(source=DEFAULT_TOP_PYPI_PACKAGES)
+            loaded = ref.get_packages(use_cache=True)
+        assert set(loaded) == set(test_packages)
+        assert mock_download.call_count == 0
+
+    def test_load_trusted_packages_from_file_invalid_packages_type(self) -> None:
+        # data['packages'] is not iterable (e.g., None or int)
+        bad_json = '{"data": {"packages": null, "count": 1, "saved_date": "2025-08-21"}}'
+        handler = DummyFileHandler(bad_json)
+        ref = TopPyPiReference(source="dummy")
+        pkgs, outdated = ref._load_trusted_packages_from_file(handler)
+        assert pkgs == set()
+        assert outdated is True
+
+    def test_load_trusted_packages_from_file_invalid_json(self) -> None:
+        handler = DummyFileHandler("{invalid json")
+        ref = TopPyPiReference(source="dummy")
+        pkgs, outdated = ref._load_trusted_packages_from_file(handler)
+        assert pkgs == set()
+        assert outdated is True
+
+    def test_load_trusted_packages_from_file_missing_data_key(self) -> None:
+        bad_json = '{"not_data": {}}'
+        handler = DummyFileHandler(bad_json)
+        ref = TopPyPiReference(source="dummy")
+        pkgs, outdated = ref._load_trusted_packages_from_file(handler)
+        assert pkgs == set()
+        assert outdated is True
+
+    def test_load_trusted_packages_from_file_missing_saved_date(self) -> None:
+        bad_json = '{"data": {"packages": ["foo"], "count": 1}}'
+        handler = DummyFileHandler(bad_json)
+        ref = TopPyPiReference(source="dummy")
+        pkgs, outdated = ref._load_trusted_packages_from_file(handler)
+        assert pkgs == set()
+        assert outdated is True
+
+    def test_load_trusted_packages_from_file_invalid_date_format(self) -> None:
+        bad_json = '{"data": {"packages": ["foo"], "count": 1, "saved_date": "not-a-date"}}'
+        handler = DummyFileHandler(bad_json)
+        ref = TopPyPiReference(source="dummy")
+        pkgs, outdated = ref._load_trusted_packages_from_file(handler)
+        assert pkgs == set()
+        assert outdated is True

--- a/uv.lock
+++ b/uv.lock
@@ -339,6 +339,18 @@ wheels = [
 ]
 
 [[package]]
+name = "freezegun"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/dd/23e2f4e357f8fd3bdff613c1fe4466d21bfb00a6177f238079b17f7b1c84/freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a", size = 35914, upload-time = "2025-08-09T10:39:08.338Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/2e/b41d8a1a917d6581fc27a35d05561037b048e47df50f27f8ac9c7e27a710/freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2", size = 19266, upload-time = "2025-08-09T10:39:06.636Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -848,6 +860,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1068,6 +1092,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1164,10 +1197,12 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "freezegun" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-python-dateutil" },
     { name = "types-requests" },
 ]
 local = [
@@ -1190,16 +1225,27 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "freezegun", specifier = ">=1.5.5" },
     { name = "mypy", specifier = ">=0.982,<1.17" },
     { name = "pytest", specifier = ">=7.1.3,<9.0.0" },
     { name = "pytest-cov", specifier = ">=4,<7" },
     { name = "ruff", specifier = ">=0.5.1,<0.12.4" },
+    { name = "types-python-dateutil", specifier = ">=2.9.0.20250809" },
     { name = "types-requests", specifier = ">=2.32.4.20250611,<3.0.0.0" },
 ]
 local = [
     { name = "commitizen", specifier = ">=2.38,<5.0" },
     { name = "ipdb", specifier = ">=0.13.9,<1.0.0" },
     { name = "pdbpp", specifier = ">=0.11.6,<1.0.0" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20250809"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/53/07dac71db45fb6b3c71c2fd29a87cada2239eac7ecfb318e6ebc7da00a3b/types_python_dateutil-2.9.0.20250809.tar.gz", hash = "sha256:69cbf8d15ef7a75c3801d65d63466e46ac25a0baa678d89d0a137fc31a608cc1", size = 15820, upload-time = "2025-08-09T03:14:14.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/5e/67312e679f612218d07fcdbd14017e6d571ce240a5ba1ad734f15a8523cc/types_python_dateutil-2.9.0.20250809-py3-none-any.whl", hash = "sha256:768890cac4f2d7fd9e0feb6f3217fce2abbfdfc0cadd38d11fba325a815e4b9f", size = 17707, upload-time = "2025-08-09T03:14:13.314Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds the possibility to save the downloaded trusted packages to a local cache file, to speed up runs. 

This will mostly benefit local use of `twyn`  and not so much the use in CI. That's why we assume the timezone will remain the same.

To disable cache usage one can run `twyn --no-cache`. Otherwise the cache will be used. 

The capability of disabling/enabling cache via the config file will come in a future PR, as well as the possiblity of completely erasing it.

Refs #143