### PR TITLE
fix: run conventional-label only on main

### DIFF
--- a/.github/workflows/conventional-label.yaml
+++ b/.github/workflows/conventional-label.yaml
@@ -1,6 +1,7 @@
 on:
   pull_request_target:
-    types: [opened, edited]
+    branches: ["main"]
+
 name: conventional-release-labels
 jobs:
   label:


### PR DESCRIPTION
This check was also running on forks, while it shouldn't