### PR TITLE
feat: expose `check_dependencies` to the main interface

### DIFF
--- a/src/twyn/__init__.py
+++ b/src/twyn/__init__.py
@@ -1,0 +1,3 @@
+from twyn.main import check_dependencies
+
+__all__ = ["check_dependencies"]


### PR DESCRIPTION
This will help with development when `twyn` is used as a library.