### PR TITLE
feat: allow to disable track while evaluating dependencies

### DIFF
--- a/src/twyn/cli.py
+++ b/src/twyn/cli.py
@@ -76,6 +76,12 @@ def entry_point() -> None:
     default=False,
     help="Disable use of the trusted packages cache. Always fetch from the source.",
 )
+@click.option(
+    "--no-track",
+    is_flag=True,
+    default=False,
+    help="Do not show the progress bar while processing packages.",
+)
 def run(
     config: str,
     dependency_file: Optional[str],
@@ -84,6 +90,7 @@ def run(
     v: bool,
     vv: bool,
     no_cache: bool,
+    no_track: bool,
 ) -> int:
     if v and vv:
         raise click.UsageError(
@@ -113,6 +120,7 @@ def run(
             selector_method=selector_method,
             verbosity=verbosity,
             use_cache=not no_cache,
+            use_track=not no_track,
         )
     except TwynError as e:
         raise CliError(e.message) from e

--- a/src/twyn/main.py
+++ b/src/twyn/main.py
@@ -32,6 +32,7 @@ def check_dependencies(
     dependencies: Optional[set[str]] = None,
     verbosity: AvailableLoggingLevels = AvailableLoggingLevels.none,
     use_cache: bool = True,
+    use_track: bool = False,
 ) -> list[TyposquatCheckResult]:
     """Check if dependencies could be typosquats."""
     config_file_handler = FileHandler(config_file or DEFAULT_PROJECT_TOML_FILE)
@@ -52,7 +53,10 @@ def check_dependencies(
     normalized_dependencies = normalize_packages(dependencies)
 
     errors: list[TyposquatCheckResult] = []
-    for dependency in track(normalized_dependencies, description="Processing..."):
+    dependencies_list = (
+        track(normalized_dependencies, description="Processing...") if use_track else normalized_dependencies
+    )
+    for dependency in dependencies_list:
         if dependency in normalized_allowlist_packages:
             logger.info("Dependency %s is in the allowlist", dependency)
             continue

--- a/tests/main/test_cli.py
+++ b/tests/main/test_cli.py
@@ -89,6 +89,7 @@ class TestCli:
                 selector_method="first-letter",
                 verbosity=AvailableLoggingLevels.debug,
                 use_cache=True,
+                use_track=True,
             )
         ]
 
@@ -111,6 +112,7 @@ class TestCli:
                 selector_method=None,
                 verbosity=AvailableLoggingLevels.none,
                 use_cache=True,
+                use_track=True,
             )
         ]
 
@@ -132,6 +134,7 @@ class TestCli:
                 selector_method=None,
                 verbosity=AvailableLoggingLevels.none,
                 use_cache=True,
+                use_track=True,
             )
         ]
 
@@ -165,6 +168,7 @@ class TestCli:
                 selector_method=None,
                 verbosity=AvailableLoggingLevels.none,
                 use_cache=True,
+                use_track=True,
             )
         ]
 
@@ -181,6 +185,7 @@ class TestCli:
                 dependencies=None,
                 verbosity=AvailableLoggingLevels.none,
                 use_cache=True,
+                use_track=True,
             )
         ]
 

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -283,3 +283,23 @@ class TestCheckDependencies:
         mock_get_dependency_parser.return_value = RequirementsTxtParser()
         mock_parse.return_value = {"boto3"}
         assert get_parsed_dependencies_from_file() == {"boto3"}
+
+    @patch("twyn.main.TopPyPiReference")
+    @patch("twyn.main.get_parsed_dependencies_from_file")
+    def test_track_is_disabled_by_default_when_used_as_package(
+        self, mock_get_parsed_dependencies_from_file, mock_top_pypi_reference
+    ) -> None:
+        mock_top_pypi_reference.return_value.get_packages.return_value = {"mypackage"}
+        mock_get_parsed_dependencies_from_file.return_value = {"my-package"}
+        with patch("twyn.main.track") as m_track:
+            check_dependencies("all")
+        assert m_track.call_count == 0
+
+    @patch("twyn.main.TopPyPiReference")
+    @patch("twyn.main.get_parsed_dependencies_from_file")
+    def test_track_is_shown_when_enabled(self, mock_get_parsed_dependencies_from_file, mock_top_pypi_reference) -> None:
+        mock_top_pypi_reference.return_value.get_packages.return_value = {"mypackage"}
+        mock_get_parsed_dependencies_from_file.return_value = {"my-package"}
+        with patch("twyn.main.track") as m_track:
+            check_dependencies("all", use_track=True)
+        assert m_track.call_count == 1


### PR DESCRIPTION
This PR adds the capability of disabling the track through the cli as well as from the public package interface.

When running twyn as a cli tool by default the track is shown, whereas while it's being used as a package it is disabled.

closes #281 