### PR TITLE
feat: allow to get results as json

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,12 +6,6 @@ from unittest import mock
 import pytest
 
 
-@pytest.fixture(autouse=True)
-def disable_click_echo():
-    with mock.patch("click.echo"):
-        yield
-
-
 @contextmanager
 def create_tmp_file(path: Path, data: str) -> Iterator[str]:
     path.write_text(data)

--- a/tests/trusted_packages/test_trusted_packages.py
+++ b/tests/trusted_packages/test_trusted_packages.py
@@ -118,5 +118,5 @@ class TestTrustedPackages:
         )
 
         assert trusted_packages.get_typosquat(package_name=package_name) == TyposquatCheckResult(
-            candidate_dependency=package_name, similar_dependencies=matches
+            dependency=package_name, similars=matches
         )


### PR DESCRIPTION
Introduces `--json` flag to return the results as a json.

It no longer uses click.echo, for some reason it is not captured in the output and it's impossible to test.

Another important addition here is that `check_dependencies` now returns an object of the new class `TyposquatCheckResultList`. This breaks previous implementations of those using `twyn` as a package.

It also renames `candidate_dependency` to `dependency` and `similar_results` to `similarities` from the `TyposquatCheckResult` model.

BREAKING CHANGE
closes #283 