### PR TITLE
feat: make config file optional

### DIFF
--- a/src/twyn/cli.py
+++ b/src/twyn/cli.py
@@ -124,6 +124,7 @@ def run(
             verbosity=verbosity,
             use_cache=not no_cache if no_cache is not None else no_cache,
             use_track=False if json else not no_track,
+            load_config_from_file=True,
         )
     except TwynError as e:
         raise CliError(e.message) from e

--- a/src/twyn/config/exceptions.py
+++ b/src/twyn/config/exceptions.py
@@ -36,3 +36,9 @@ class InvalidSelectorMethodError(TwynError):
     """Exception for when an invalid selector method has been specified."""
 
     message = "Invalid `Selector` was provided."
+
+
+class ConfigFileNotConfiguredError(TwynError):
+    """Exception for when a read/write operation has been attempted but no config file was configured."""
+
+    message = "Config file not configured."

--- a/src/twyn/main.py
+++ b/src/twyn/main.py
@@ -32,12 +32,18 @@ def check_dependencies(
     verbosity: AvailableLoggingLevels = AvailableLoggingLevels.none,
     use_cache: Optional[bool] = True,
     use_track: bool = False,
+    load_config_from_file: bool = False,
 ) -> TyposquatCheckResultList:
     """Check if dependencies could be typosquats."""
-    config_file_handler = FileHandler(config_file or ConfigHandler.get_default_config_file_path())
-    config = ConfigHandler(config_file_handler, enforce_file=False).resolve_config(
-        verbosity=verbosity, selector_method=selector_method, dependency_file=dependency_file, use_cache=use_cache
+    config = get_config(
+        load_config_from_file=load_config_from_file,
+        config_file=config_file,
+        verbosity=verbosity,
+        selector_method=selector_method,
+        dependency_file=dependency_file,
+        use_cache=use_cache,
     )
+
     _set_logging_level(config.logging_level)
 
     cache_handler = CacheHandler() if config.use_cache else None
@@ -66,6 +72,26 @@ def check_dependencies(
             typos_list.errors.append(typosquat_results)
 
     return typos_list
+
+
+def get_config(
+    load_config_from_file: bool,
+    config_file: Optional[str],
+    verbosity: AvailableLoggingLevels,
+    selector_method: Union[SelectorMethod, None],
+    dependency_file: Optional[str],
+    use_cache: Optional[bool],
+) -> ConfigHandler:
+    if load_config_from_file:
+        config_file_handler = FileHandler(config_file or ConfigHandler.get_default_config_file_path())
+    else:
+        config_file_handler = None
+    return ConfigHandler(config_file_handler).resolve_config(
+        verbosity=verbosity,
+        selector_method=selector_method,
+        dependency_file=dependency_file,
+        use_cache=use_cache,
+    )
 
 
 def _set_logging_level(logging_level: AvailableLoggingLevels) -> None:

--- a/tests/main/test_cli.py
+++ b/tests/main/test_cli.py
@@ -91,6 +91,7 @@ class TestCli:
                 verbosity=AvailableLoggingLevels.debug,
                 use_cache=None,
                 use_track=True,
+                load_config_from_file=True,
             )
         ]
 
@@ -114,6 +115,7 @@ class TestCli:
                 verbosity=AvailableLoggingLevels.none,
                 use_cache=None,
                 use_track=True,
+                load_config_from_file=True,
             )
         ]
 
@@ -136,6 +138,7 @@ class TestCli:
                 verbosity=AvailableLoggingLevels.none,
                 use_cache=None,
                 use_track=True,
+                load_config_from_file=True,
             )
         ]
 
@@ -170,6 +173,7 @@ class TestCli:
                 verbosity=AvailableLoggingLevels.none,
                 use_cache=None,
                 use_track=True,
+                load_config_from_file=True,
             )
         ]
 
@@ -187,6 +191,7 @@ class TestCli:
                 verbosity=AvailableLoggingLevels.none,
                 use_cache=None,
                 use_track=True,
+                load_config_from_file=True,
             )
         ]
 

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -114,7 +114,7 @@ class TestCheckDependencies:
         3. default values
 
         """
-        handler = ConfigHandler(FileHandler(""), enforce_file=False)
+        handler = ConfigHandler(FileHandler(""))
 
         with patch.object(handler, "_read_toml", return_value=parse(dumps({"tool": {"twyn": file_config}}))):
             resolved = handler.resolve_config(


### PR DESCRIPTION
When we're running `twyn` as a 3rd party package, we may not want the config to be loaded from the config file. 

This PR introduces the possibility to decide whether or not to use it.

Since it default to False (only for when it's used as a library!), it is a breaking change.

closes #294 

BREAKING CHANGE