### PR TITLE
refactor: remove custom logging implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   - [Configuration file](#configuration-file)
   - [Cache](#cache)
 - [Using `Twyn` as a library](#using-twyn-as-a-library)
+  - [Logging level](#logging-level)
 
 ## Overview
 `Twyn` is a security tool that compares the name of your dependencies against a set of the most popular ones,
@@ -213,4 +214,11 @@ for typo in typos.errors:
   print(f"Dependency:{typo.dependency}")
   print(f"Did you mean any of [{','.join(typo.similars)}]")
   
+```
+### Logging level
+To override the logging level when using `Twyn` as a 3rd party library, simply override it like:
+
+```python
+logging.basicConfig(level=logging.DEBUG)
+logging.getLogger("twyn").setLevel(logging.DEBUG)
 ```

--- a/src/twyn/base/constants.py
+++ b/src/twyn/base/constants.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from enum import Enum
 from typing import TYPE_CHECKING, Literal
 
 from twyn import dependency_parser
@@ -30,10 +29,3 @@ DEFAULT_PROJECT_TOML_FILE = "pyproject.toml"
 DEFAULT_TWYN_TOML_FILE = "twyn.toml"
 DEFAULT_TOP_PYPI_PACKAGES = "https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json"
 DEFAULT_USE_CACHE = True
-
-
-class AvailableLoggingLevels(Enum):
-    none = "NONE"
-    debug = "DEBUG"
-    info = "INFO"
-    warning = "WARNING"

--- a/src/twyn/base/exceptions.py
+++ b/src/twyn/base/exceptions.py
@@ -3,7 +3,7 @@ from typing import IO, Any, Optional
 
 import click
 
-logger = logging.getLogger("twyn.errors")
+logger = logging.getLogger("twyn")
 
 
 class TwynError(Exception):

--- a/src/twyn/cli.py
+++ b/src/twyn/cli.py
@@ -11,7 +11,6 @@ from twyn.base.constants import (
     DEFAULT_PROJECT_TOML_FILE,
     DEPENDENCY_FILE_MAPPING,
     SELECTOR_METHOD_MAPPING,
-    AvailableLoggingLevels,
 )
 from twyn.base.exceptions import CliError, TwynError
 from twyn.config.config_handler import ConfigHandler
@@ -101,11 +100,9 @@ def run(
     json: bool,
 ) -> int:
     if vv:
-        verbosity = AvailableLoggingLevels.debug
+        logger.setLevel(logging.DEBUG)
     elif v:
-        verbosity = AvailableLoggingLevels.info
-    else:
-        verbosity = AvailableLoggingLevels.none
+        logger.setLevel(logging.INFO)
 
     if dependency and dependency_file:
         raise click.UsageError(
@@ -121,9 +118,8 @@ def run(
             dependencies=set(dependency) or None,
             config_file=config,
             dependency_file=dependency_file,
-            verbosity=verbosity,
             use_cache=not no_cache if no_cache is not None else no_cache,
-            use_track=False if json else not no_track,
+            show_progress_bar=False if json else not no_track,
             load_config_from_file=True,
         )
     except TwynError as e:

--- a/src/twyn/config/config_handler.py
+++ b/src/twyn/config/config_handler.py
@@ -13,7 +13,6 @@ from twyn.base.constants import (
     DEFAULT_TWYN_TOML_FILE,
     DEFAULT_USE_CACHE,
     SELECTOR_METHOD_KEYS,
-    AvailableLoggingLevels,
 )
 from twyn.config.exceptions import (
     AllowlistPackageAlreadyExistsError,
@@ -34,7 +33,6 @@ class TwynConfiguration:
 
     dependency_file: Optional[str]
     selector_method: str
-    logging_level: AvailableLoggingLevels
     allowlist: set[str]
     pypi_reference: str
     use_cache: bool
@@ -46,7 +44,6 @@ class ReadTwynConfiguration:
 
     dependency_file: Optional[str] = None
     selector_method: Optional[str] = None
-    logging_level: Optional[AvailableLoggingLevels] = None
     allowlist: set[str] = field(default_factory=set)
     pypi_reference: Optional[str] = None
     use_cache: Optional[bool] = None
@@ -62,7 +59,6 @@ class ConfigHandler:
         self,
         selector_method: Optional[str] = None,
         dependency_file: Optional[str] = None,
-        verbosity: AvailableLoggingLevels = AvailableLoggingLevels.none,
         use_cache: Optional[bool] = None,
     ) -> TwynConfiguration:
         """Resolve the configuration for Twyn.
@@ -99,7 +95,6 @@ class ConfigHandler:
         return TwynConfiguration(
             dependency_file=dependency_file or read_config.dependency_file,
             selector_method=final_selector_method,
-            logging_level=_get_logging_level(verbosity, read_config.logging_level),
             allowlist=read_config.allowlist,
             pypi_reference=read_config.pypi_reference or DEFAULT_TOP_PYPI_PACKAGES,
             use_cache=final_use_cache,
@@ -133,7 +128,6 @@ class ConfigHandler:
         return ReadTwynConfiguration(
             dependency_file=twyn_config_data.get("dependency_file"),
             selector_method=twyn_config_data.get("selector_method"),
-            logging_level=twyn_config_data.get("logging_level"),
             allowlist=set(twyn_config_data.get("allowlist", set())),
             pypi_reference=twyn_config_data.get("pypi_reference"),
             use_cache=twyn_config_data.get("use_cache"),
@@ -177,20 +171,6 @@ class ConfigHandler:
         if Path(DEFAULT_TWYN_TOML_FILE).exists():
             return DEFAULT_TWYN_TOML_FILE
         return DEFAULT_PROJECT_TOML_FILE
-
-
-def _get_logging_level(
-    cli_verbosity: AvailableLoggingLevels,
-    config_logging_level: Optional[str],
-) -> AvailableLoggingLevels:
-    """Return the appropriate logging level, considering that the one in config has less priority than the one passed directly."""
-    if cli_verbosity is AvailableLoggingLevels.none:
-        if config_logging_level:
-            return AvailableLoggingLevels[config_logging_level.lower()]
-        else:
-            # default logging level
-            return AvailableLoggingLevels.warning
-    return cli_verbosity
 
 
 def _serialize_config(x: Any) -> Union[Any, str, list[Any]]:

--- a/tests/config/test_config_handler.py
+++ b/tests/config/test_config_handler.py
@@ -11,7 +11,6 @@ from twyn.base.constants import (
     DEFAULT_SELECTOR_METHOD,
     DEFAULT_TOP_PYPI_PACKAGES,
     DEFAULT_TWYN_TOML_FILE,
-    AvailableLoggingLevels,
 )
 from twyn.config.config_handler import ConfigHandler, ReadTwynConfiguration, TwynConfiguration
 from twyn.config.exceptions import (
@@ -40,7 +39,6 @@ class TestConfigHandler:
         assert config == TwynConfiguration(
             dependency_file=None,
             selector_method="all",
-            logging_level=AvailableLoggingLevels.warning,
             allowlist=set(),
             pypi_reference=DEFAULT_TOP_PYPI_PACKAGES,
             use_cache=True,
@@ -54,7 +52,6 @@ class TestConfigHandler:
         config = ConfigHandler(file_handler=FileHandler(pyproject_toml_file)).resolve_config()
         assert config.dependency_file == "my_file.txt"
         assert config.selector_method == "all"
-        assert config.logging_level == AvailableLoggingLevels.debug
         assert config.allowlist == {"boto4", "boto2"}
         assert config.use_cache is False
 
@@ -66,7 +63,6 @@ class TestConfigHandler:
         assert twyn_data == ReadTwynConfiguration(
             dependency_file="my_file.txt",
             selector_method="all",
-            logging_level="debug",
             allowlist={"boto4", "boto2"},
             pypi_reference=None,
             use_cache=False,
@@ -105,7 +101,6 @@ class TestConfigHandler:
                 "twyn": {
                     "dependency_file": "my_file.txt",
                     "selector_method": "all",
-                    "logging_level": "debug",
                     "allowlist": {},
                     "pypi_reference": DEFAULT_TOP_PYPI_PACKAGES,
                     "use_cache": False,
@@ -146,7 +141,6 @@ class TestConfigHandler:
 
         assert config.allowlist == set()
         assert config.dependency_file is None
-        assert config.logging_level == AvailableLoggingLevels.warning
         assert config.use_cache is True
         assert config.selector_method == DEFAULT_SELECTOR_METHOD
         assert config.pypi_reference == DEFAULT_TOP_PYPI_PACKAGES

--- a/tests/main/test_cli.py
+++ b/tests/main/test_cli.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock, call, patch
 import pytest
 from click.testing import CliRunner
 from twyn import cli
-from twyn.base.constants import AvailableLoggingLevels
 from twyn.base.exceptions import TwynError
 from twyn.trusted_packages.cache_handler import CacheEntry, CacheHandler
 from twyn.trusted_packages.trusted_packages import TyposquatCheckResult, TyposquatCheckResultList
@@ -88,9 +87,8 @@ class TestCli:
                 dependency_file="requirements.txt",
                 dependencies=None,
                 selector_method="first-letter",
-                verbosity=AvailableLoggingLevels.debug,
                 use_cache=None,
-                use_track=True,
+                show_progress_bar=True,
                 load_config_from_file=True,
             )
         ]
@@ -112,9 +110,8 @@ class TestCli:
                 dependency_file="/path/requirements.txt",
                 dependencies=None,
                 selector_method=None,
-                verbosity=AvailableLoggingLevels.none,
                 use_cache=None,
-                use_track=True,
+                show_progress_bar=True,
                 load_config_from_file=True,
             )
         ]
@@ -135,9 +132,8 @@ class TestCli:
                 dependency_file=None,
                 dependencies={"reqests"},
                 selector_method=None,
-                verbosity=AvailableLoggingLevels.none,
                 use_cache=None,
-                use_track=True,
+                show_progress_bar=True,
                 load_config_from_file=True,
             )
         ]
@@ -170,9 +166,8 @@ class TestCli:
                 dependency_file=None,
                 dependencies={"reqests", "reqeusts"},
                 selector_method=None,
-                verbosity=AvailableLoggingLevels.none,
                 use_cache=None,
-                use_track=True,
+                show_progress_bar=True,
                 load_config_from_file=True,
             )
         ]
@@ -188,9 +183,8 @@ class TestCli:
                 dependency_file=None,
                 selector_method=None,
                 dependencies=None,
-                verbosity=AvailableLoggingLevels.none,
                 use_cache=None,
-                use_track=True,
+                show_progress_bar=True,
                 load_config_from_file=True,
             )
         ]


### PR DESCRIPTION
I'm removing the custom logging level handler that we had from the early days, in favor of a more simplistic approach where the user can simply modify `twyn`'s logger as any other logger.

This PR introduces the following behaviours:
- When running as a cli tool, the logging level is set as specified in the cli
- When running as a 3rd party library, all logging is disabled by default. The user can set the logging level as they wish before using twyn by configuring the "twyn logger".

closes #303 
BREAKING CHANGE