### PR TITLE
feat: support parsing multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In short, `Twyn` protects you against [typosquatting attacks](https://en.wikiped
 
 It works as follows:
 
-1. Either choose to scan the dependencies in a dependencies file you specify (`--dependency-file`) or some dependencies introduced through the CLI (`--dependency`). If no option was provided, it will try to find a dependencies file in your working path.
+1. Either choose to scan the dependencies in a dependencies file you specify (`--dependency-file`) or some dependencies introduced through the CLI (`--dependency`). If no option was provided, it will try to find a dependencies file in your working path. It will try to parse all the supported dependency files that it finds. To know which files are supported head to the [Dependency files](#dependency-files) section.
 2. If the name of your package name matches with the name of one of the most well known packages, the package is accepted.
 3. If the name of your package is similar to the name of one of the most used packages, `Twyn` will prompt an error.
 4. If your package name is not in the list of the most known ones and is not similar enough to any of those to be considered misspelled, the package is accepted. `Twyn` assumes that you're using either a not so popular package (therefore it can't verify its legitimacy) or a package created by yourself, therefore unknown for the rest.
@@ -84,8 +84,43 @@ If you want your output in JSON format, you can run `Twyn` with the following fl
 This will output:
 
  ```json
-  {"errors":[{"dependency":"reqests","similars":["requests","grequests"]}]}
+  {"results":[{"errors":[{"dependency":"my-package","similars":["mypackage"]}],"source":"manual_input"}]}
  ```
+If `Twyn` was run by manually giving it dependencies (with `--dependency`), the source will be `manual_input`. 
+
+In any other case (when dependencies are parsed from a file), the source will be the path to the dependencies file. One entry will be created for every source.
+
+### Using Twyn as a library
+
+
+#### Installation
+`Twyn` also supports being used as 3rd party library for you project. To install it, run:
+
+
+```sh
+pip install twyn
+```
+
+Example usage in your code:
+
+```python
+from twyn import check_dependencies
+
+typos = check_dependencies()
+
+for typo in typos.errors:
+  print(f"Dependency:{typo.dependency}")
+  print(f"Did you mean any of [{','.join(typo.similars)}]")
+  
+```
+
+#### Logging level
+By default, logging is disabled when running as a 3rd party library. To override this behaviour, you can:
+
+```python
+logging.basicConfig(level=logging.INFO)
+logging.getLogger("twyn").setLevel(logging.INFO)
+```
 
 ### Using Twyn as a library
 

--- a/dependencies/scripts/download_packages.py
+++ b/dependencies/scripts/download_packages.py
@@ -61,7 +61,7 @@ def download(ecosystem: str) -> None:
     ):
         with attempt, httpx.Client(timeout=30) as client:
             logger.info("Attempting to download %s packages. Attempt #%d.", ecosystem, attempt.num)
-            response = client.get(ECOSYSTEMS[ecosystem]["url"])
+            response = client.get(str(ECOSYSTEMS[ecosystem]["url"]))
             response.raise_for_status()
 
     fpath = Path("dependencies") / f"{ecosystem}.json"

--- a/src/twyn/base/constants.py
+++ b/src/twyn/base/constants.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
     from twyn.dependency_parser.parsers.abstract_parser import AbstractParser
 
 
+MANUAL_INPUT_SOURCE = "manual_input"
+
 SELECTOR_METHOD_MAPPING: dict[str, type[selectors.AbstractSelector]] = {
     "first-letter": selectors.FirstLetterExact,
     "nearby-letter": selectors.FirstLetterNearbyInKeyboard,

--- a/src/twyn/cli.py
+++ b/src/twyn/cli.py
@@ -103,7 +103,7 @@ def entry_point() -> None:
     default=False,
     help="Display the results in json format. It implies --no-track.",
 )
-def run(
+def run(  # noqa: C901
     config: str,
     dependency_file: Optional[str],
     dependency: tuple[str],
@@ -146,14 +146,15 @@ def run(
 
     if json:
         click.echo(possible_typos.model_dump_json())
-        sys.exit(int(bool(possible_typos.errors)))
-    elif possible_typos.errors:
-        for possible_typosquats in possible_typos.errors:
-            click.echo(
-                click.style("Possible typosquat detected: ", fg="red") + f"`{possible_typosquats.dependency}`, "
-                f"did you mean any of [{', '.join(possible_typosquats.similars)}]?",
-                color=True,
-            )
+        sys.exit(int(bool(possible_typos)))
+    elif possible_typos:
+        for possible_typosquats in possible_typos.results:
+            for error in possible_typosquats.errors:
+                click.echo(
+                    click.style("Possible typosquat detected: ", fg="red") + f"`{error.dependency}`, "
+                    f"did you mean any of [{', '.join(error.similars)}]?",
+                    color=True,
+                )
         sys.exit(1)
     else:
         click.echo(click.style("No typosquats detected", fg="green"), color=True)

--- a/src/twyn/dependency_parser/dependency_selector.py
+++ b/src/twyn/dependency_parser/dependency_selector.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 from twyn.base.constants import DEPENDENCY_FILE_MAPPING
 from twyn.dependency_parser.exceptions import (
-    MultipleParsersError,
     NoMatchingParserError,
 )
 from twyn.dependency_parser.parsers.abstract_parser import AbstractParser
@@ -15,46 +14,36 @@ class DependencySelector:
     def __init__(self, dependency_file: Optional[str] = None) -> None:
         self.dependency_file = dependency_file or ""
 
-    @staticmethod
-    def _raise_for_selected_parsers(parsers: list[type[AbstractParser]]) -> None:
-        if len(parsers) > 1:
-            raise MultipleParsersError
+    def auto_detect_dependency_file_parser(self) -> list[AbstractParser]:
+        parsers: list[AbstractParser] = []
+        for dependency_parser in DEPENDENCY_FILE_MAPPING.values():
+            file_parser = dependency_parser()
+            if file_parser.file_exists():
+                parsers.append(file_parser)
+                logger.debug("Assigned %s parser for local dependencies file.", file_parser)
 
         if not parsers:
             raise NoMatchingParserError
 
-    def auto_detect_dependency_file_parser(self) -> type[AbstractParser]:
-        parsers: list[AbstractParser] = [
-            dependency_parser
-            for dependency_parser in DEPENDENCY_FILE_MAPPING.values()
-            if dependency_parser().file_exists()
-        ]
-        self._raise_for_selected_parsers(parsers)
-        self.dependency_file = parsers[0]().file_path
         logger.debug("Dependencies file found")
-        return parsers[0]
+        return parsers
 
-    def get_dependency_file_parser_from_file_name(
-        self,
-    ) -> type[AbstractParser]:
+    def get_dependency_file_parsers_from_file_name(self) -> list[AbstractParser]:
         parsers = []
         for known_dependency_file_name in DEPENDENCY_FILE_MAPPING:
             if self.dependency_file.endswith(known_dependency_file_name):
-                parsers.append(DEPENDENCY_FILE_MAPPING[known_dependency_file_name])
+                file_parser = DEPENDENCY_FILE_MAPPING[known_dependency_file_name](self.dependency_file)
+                parsers.append(file_parser)
 
-        self._raise_for_selected_parsers(parsers)
-        return parsers[0]
+        if not parsers:
+            raise NoMatchingParserError
 
-    def get_dependency_parser(self) -> AbstractParser:
+        return parsers
+
+    def get_dependency_parsers(self) -> list[AbstractParser]:
         if self.dependency_file:
             logger.debug("Dependency file provided. Assigning a parser.")
-            dependency_file_parser = self.get_dependency_file_parser_from_file_name()
-            file_parser = dependency_file_parser(self.dependency_file)
-        else:
-            logger.debug("No dependency file provided. Attempting to locate one.")
-            dependency_file_parser = self.auto_detect_dependency_file_parser()
-            file_parser = dependency_file_parser()
+            return self.get_dependency_file_parsers_from_file_name()
 
-        logger.debug("Assigned %s parser for local dependencies file.", file_parser)
-
-        return file_parser
+        logger.debug("No dependency file provided. Attempting to locate one.")
+        return self.auto_detect_dependency_file_parser()

--- a/src/twyn/main.py
+++ b/src/twyn/main.py
@@ -3,27 +3,32 @@ from collections.abc import Iterable
 from typing import Optional, Union
 
 from twyn.base.constants import (
+    MANUAL_INPUT_SOURCE,
     SELECTOR_METHOD_MAPPING,
     PackageEcosystems,
     SelectorMethod,
 )
 from twyn.config.config_handler import ConfigHandler, TwynConfiguration
 from twyn.config.exceptions import InvalidSelectorMethodError
+from twyn.dependency_managers.managers.base import BaseDependencyManager
 from twyn.dependency_managers.utils import (
     PACKAGE_ECOSYSTEMS,
     get_dependency_manager_from_file,
     get_dependency_manager_from_name,
 )
 from twyn.dependency_parser.dependency_selector import DependencySelector
+from twyn.dependency_parser.parsers.abstract_parser import AbstractParser
 from twyn.file_handler.file_handler import FileHandler
 from twyn.similarity.algorithm import EditDistance, SimilarityThreshold
 from twyn.trusted_packages.cache_handler import CacheHandler
 from twyn.trusted_packages.exceptions import InvalidArgumentsError
-from twyn.trusted_packages.references.base import AbstractPackageReference
-from twyn.trusted_packages.trusted_packages import (
-    TrustedPackages,
-    TyposquatCheckResultList,
+from twyn.trusted_packages.models import (
+    TyposquatCheckResultEntry,
+    TyposquatCheckResultFromSource,
+    TyposquatCheckResults,
 )
+from twyn.trusted_packages.references.base import AbstractPackageReference
+from twyn.trusted_packages.trusted_packages import TrustedPackages
 
 logger = logging.getLogger("twyn")
 logger.addHandler(logging.NullHandler())
@@ -38,7 +43,7 @@ def check_dependencies(
     show_progress_bar: bool = False,
     load_config_from_file: bool = False,
     package_ecosystem: Optional[PackageEcosystems] = None,
-) -> TyposquatCheckResultList:
+) -> TyposquatCheckResults:
     """
     Check if the provided dependencies are potential typosquats of trusted packages.
 
@@ -66,27 +71,127 @@ def check_dependencies(
         use_cache=use_cache,
         package_ecosystem=package_ecosystem,
     )
+    maybe_cache_handler = CacheHandler() if config.use_cache else None
+    selector_method_obj = _get_selector_method(config.selector_method)
 
-    selector_method = _get_selector_method(config.selector_method)
+    if dependencies:  # Dependencies where input manually, will not read dependency files.
+        return _analyze_dependencies_from_input(
+            selector_method=selector_method_obj,
+            source=config.source,
+            maybe_cache_handler=maybe_cache_handler,
+            allowlist=config.allowlist,
+            show_progress_bar=show_progress_bar,
+            package_ecosystem=config.package_ecosystem,
+            dependencies=dependencies,
+        )
 
-    dependencies_to_check, top_package_reference = _get_dependencies_to_check_and_top_package_reference(
-        config.package_ecosystem,
-        dependencies,
-        config.source,
-        config.dependency_file,
-        config.use_cache,
+    if config.package_ecosystem:
+        logger.warning("`package_ecosystem` is not supported when reading dependencies from files. It will be ignored.")
+
+    return _analyze_packages_from_source(
+        selector_method=selector_method_obj,
+        source=config.source,
+        maybe_cache_handler=maybe_cache_handler,
+        allowlist=config.allowlist,
+        show_progress_bar=show_progress_bar,
+        dependency_file=config.dependency_file,
     )
 
+
+def _analyze_dependencies_from_input(
+    package_ecosystem: Optional[PackageEcosystems],
+    selector_method: SelectorMethod,
+    source: Optional[str],
+    maybe_cache_handler: Optional[CacheHandler],
+    dependencies: set[str],
+    allowlist: set[str],
+    show_progress_bar: bool,
+) -> TyposquatCheckResults:
+    """Analyze dependencies when they are passed as an argument to the main method.
+
+    All dependencies analyzed like this will have as source `manual_input`.
+    """
+    if not package_ecosystem:
+        raise InvalidArgumentsError("`package_ecosystem` is required when using `dependencies`.")
+    if package_ecosystem not in PACKAGE_ECOSYSTEMS:
+        raise InvalidArgumentsError("Not a valid `package_ecosystem`.")
+
+    dependency_manager = get_dependency_manager_from_name(package_ecosystem)
+    top_package_reference = dependency_manager.trusted_packages_source(source, maybe_cache_handler)
     trusted_packages = TrustedPackages(
         names=top_package_reference.get_packages(),
         algorithm=EditDistance(),
         selector=selector_method,
         threshold_class=SimilarityThreshold,
     )
-    normalized_allowlist_packages = top_package_reference.normalize_packages(config.allowlist)
-    normalized_dependencies = top_package_reference.normalize_packages(dependencies_to_check)
+    possible_typos = _analyze_dependencies(
+        top_package_reference, trusted_packages, dependencies, allowlist, show_progress_bar
+    )
+    if possible_typos:
+        return TyposquatCheckResults(
+            results=[
+                TyposquatCheckResultFromSource(
+                    errors=possible_typos,
+                    source=MANUAL_INPUT_SOURCE,
+                )
+            ]
+        )
+    return TyposquatCheckResults()
 
-    typos_list = TyposquatCheckResultList()
+
+def _analyze_packages_from_source(
+    allowlist: set[str],
+    selector_method: SelectorMethod,
+    show_progress_bar: bool,
+    dependency_file: Optional[str],
+    source: Optional[str],
+    maybe_cache_handler: Optional[CacheHandler],
+) -> TyposquatCheckResults:
+    """Analyze dependencies from a dependencies file.
+
+    It will return a list of the possible typos grouped by source, each source being a dependency file.
+    """
+    dependency_managers = _get_dependency_managers_and_parsers_mapping(dependency_file)
+    typos_by_file = TyposquatCheckResults()
+    for dependency_manager, parsers in dependency_managers.items():
+        top_package_reference = dependency_manager.trusted_packages_source(source, maybe_cache_handler)
+        packages_from_source = top_package_reference.get_packages()
+        trusted_packages = TrustedPackages(
+            names=packages_from_source,
+            algorithm=EditDistance(),
+            selector=selector_method,
+            threshold_class=SimilarityThreshold,
+        )
+        results: list[TyposquatCheckResultFromSource] = []
+        for parser in parsers:
+            analyzed_dependencies = _analyze_dependencies(
+                top_package_reference, trusted_packages, parser.parse(), allowlist, show_progress_bar
+            )
+
+            if analyzed_dependencies:
+                results.append(
+                    TyposquatCheckResultFromSource(source=str(parser.file_path), errors=analyzed_dependencies)
+                )
+        typos_by_file.results += results
+
+    return typos_by_file
+
+
+def _analyze_dependencies(
+    top_package_reference: AbstractPackageReference,
+    trusted_packages: TrustedPackages,
+    packages: set[str],
+    allowlist: set[str],
+    show_progress_bar: bool,
+) -> list[TyposquatCheckResultEntry]:
+    """Analyze the set of given dependencies against the trusted packages' golden set.
+
+    Each possible typo is returned in a `TyposquatCheckResultEntry`. A list of possible typos will be returned.
+    """
+    normalized_allowlist_packages = top_package_reference.normalize_packages(allowlist)
+    normalized_dependencies = top_package_reference.normalize_packages(packages)
+
+    errors = []
 
     for dependency in _get_dependencies_list(normalized_dependencies, show_progress_bar):
         if dependency in normalized_allowlist_packages:
@@ -95,11 +200,13 @@ def check_dependencies(
 
         logger.info("Analyzing %s", dependency)
         if dependency not in trusted_packages and (typosquat_results := trusted_packages.get_typosquat(dependency)):
-            typos_list.errors.append(typosquat_results)
-    return typos_list
+            errors.append(typosquat_results)
+
+    return errors
 
 
 def _get_dependencies_list(normalized_dependencies: set[str], show_progress_bar: bool) -> Iterable[str]:
+    """Determine if the progress bar will be showed or not. It returns an iterable of all the dependencies to analyze."""
     try:
         from rich.progress import track  # noqa: PLC0415
 
@@ -108,47 +215,41 @@ def _get_dependencies_list(normalized_dependencies: set[str], show_progress_bar:
             if show_progress_bar
             else normalized_dependencies
         )
-    except ImportError:
+    except ImportError as e:
+        if show_progress_bar:
+            raise InvalidArgumentsError(
+                "Cannot show progress bar because `rich` dependency is not installed. "
+                "It is only meant to be shown when running `twyn` as a cli tool. "
+                "If this is you case, install all the dependencies with `pip install twyn[cli]`. "
+            ) from e
         return normalized_dependencies
 
 
 def _get_selector_method(selector_method: str) -> SelectorMethod:
+    """Return the selector_method from set of available ones."""
     if selector_method not in SELECTOR_METHOD_MAPPING:
         InvalidSelectorMethodError("Invalid selector method")
 
     return SELECTOR_METHOD_MAPPING[selector_method]()
 
 
-def _get_dependencies_to_check_and_top_package_reference(
-    package_ecosystem: str,
-    dependencies: Optional[set[str]],
-    source: str,
+def _get_dependency_managers_and_parsers_mapping(
     dependency_file: Optional[str],
-    use_cache: bool,
-) -> tuple[Optional[set[str]], AbstractPackageReference]:
-    dependency_selector: Optional[DependencySelector] = None
-    cache_handler = CacheHandler() if use_cache else None
-
-    if dependencies:
-        if not package_ecosystem:
-            raise InvalidArgumentsError("`package_ecosystem` is required when using `dependencies`.")
-        if package_ecosystem not in PACKAGE_ECOSYSTEMS:
-            raise InvalidArgumentsError("not a valid programming language")
-
-        dependencies_to_check = dependencies
-        dependency_manager = get_dependency_manager_from_name(package_ecosystem)
-        return dependencies_to_check, dependency_manager.trusted_packages_source(source, cache_handler)
+) -> dict[type[BaseDependencyManager], list[AbstractParser]]:
+    """Return a dictionary, grouping all files to parse by their DependencyManager."""
+    dependency_managers: dict[type[BaseDependencyManager], list[AbstractParser]] = {}
 
     # No dependencies introduced via the CLI, so the dependecy file was either given or will be auto-detected
     dependency_selector = DependencySelector(dependency_file)
-    dependency_parser = dependency_selector.get_dependency_parser()
-    dependency_manager = get_dependency_manager_from_file(dependency_selector.dependency_file)
+    dependency_parsers = dependency_selector.get_dependency_parsers()
 
-    if package_ecosystem and dependency_manager.name != package_ecosystem:
-        raise InvalidArgumentsError("Given `package_ecosystem` does not match `dependency_file`'s `package_ecosystem`")
+    for parser in dependency_parsers:
+        manager = get_dependency_manager_from_file(parser.file_path)
 
-    dependencies_to_check = dependency_parser.parse()
-    return dependencies_to_check, dependency_manager.trusted_packages_source(source, cache_handler)
+        if manager not in dependency_managers:
+            dependency_managers[manager] = []
+        dependency_managers[manager].append(parser)
+    return dependency_managers
 
 
 def _get_config(
@@ -159,6 +260,7 @@ def _get_config(
     use_cache: Optional[bool],
     package_ecosystem: Optional[PackageEcosystems],
 ) -> TwynConfiguration:
+    """Given the arguments passed to the main function and the configuration loaded from the config file (if any), return a config object."""
     if load_config_from_file:
         config_file_handler = FileHandler(config_file or ConfigHandler.get_default_config_file_path())
     else:

--- a/src/twyn/trusted_packages/models.py
+++ b/src/twyn/trusted_packages/models.py
@@ -1,0 +1,50 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class TyposquatCheckResultEntry(BaseModel):
+    """Represents the result of analyzing a dependency for a possible typosquat."""
+
+    dependency: str
+    similars: list[str] = []
+
+    def __bool__(self) -> bool:
+        return bool(self.similars)
+
+    def add(self, similar_name: str) -> None:
+        """Add a similar dependency to this typosquat check result."""
+        self.similars.append(similar_name)
+
+
+class TyposquatCheckResultFromSource(BaseModel):
+    errors: list[TyposquatCheckResultEntry] = []
+    source: str
+
+    def __bool__(self) -> bool:
+        return bool(self.errors)
+
+    def __contains__(self, value: TyposquatCheckResultEntry) -> bool:
+        if not isinstance(value, TyposquatCheckResultEntry):
+            return False
+        return value in self.errors
+
+    def get_typosquats(self) -> set[str]:
+        """Return a set containing all the detected packages with a typo."""
+        return {typo.dependency for typo in self.errors}
+
+
+class TyposquatCheckResults(BaseModel):
+    results: list[TyposquatCheckResultFromSource] = []
+
+    def __bool__(self) -> bool:
+        return bool(self.results)
+
+    def get_results_from_source(self, source: str) -> Optional[TyposquatCheckResultFromSource]:
+        """Return results from a given source.
+
+        Source is either the lock file that has been analyzed or `manual_input`.
+        """
+        for result in self.results:
+            if result.source == source:
+                return result

--- a/src/twyn/trusted_packages/trusted_packages.py
+++ b/src/twyn/trusted_packages/trusted_packages.py
@@ -1,37 +1,14 @@
 from collections import defaultdict
 from typing import Any
 
-from pydantic import BaseModel
-
 from twyn.similarity.algorithm import (
     AbstractSimilarityAlgorithm,
     SimilarityThreshold,
 )
+from twyn.trusted_packages.models import TyposquatCheckResultEntry
 from twyn.trusted_packages.selectors import AbstractSelector
 
 _PackageNames = defaultdict[str, set[str]]
-
-
-class TyposquatCheckResult(BaseModel):
-    """Represents the result of analyzing a dependency for a possible typosquat."""
-
-    dependency: str
-    similars: list[str] = []
-
-    def __bool__(self) -> bool:
-        return bool(self.similars)
-
-    def add(self, similar_name: str) -> None:
-        """Add a similar dependency to this typosquat check result."""
-        self.similars.append(similar_name)
-
-
-class TyposquatCheckResultList(BaseModel):
-    errors: list[TyposquatCheckResult] = []
-
-    def get_typosquats(self) -> set[str]:
-        """Return a set containing all the detected packages with a typo."""
-        return {typo.dependency for typo in self.errors}
 
 
 class TrustedPackages:
@@ -65,7 +42,7 @@ class TrustedPackages:
     def get_typosquat(
         self,
         package_name: str,
-    ) -> TyposquatCheckResult:
+    ) -> TyposquatCheckResultEntry:
         """Check if a given package name is similar to any trusted package and returns it.
 
         Only if there is a match on the first letter can a package name be
@@ -73,7 +50,7 @@ class TrustedPackages:
         are used to determine if the package name can be considered similar.
         """
         threshold = self.threshold_class.from_name(package_name)
-        typosquat_result = TyposquatCheckResult(dependency=package_name)
+        typosquat_result = TyposquatCheckResultEntry(dependency=package_name)
         for trusted_package_name in self.selector.select_similar_names(names=self.names, name=package_name):
             distance = self.algorithm.get_distance(package_name, trusted_package_name)
             if threshold.is_inside_threshold(distance):

--- a/tests/trusted_packages/test_models.py
+++ b/tests/trusted_packages/test_models.py
@@ -1,0 +1,50 @@
+import pytest
+from pydantic import ValidationError
+from twyn.trusted_packages.models import (
+    TyposquatCheckResultEntry,
+    TyposquatCheckResultFromSource,
+    TyposquatCheckResults,
+)
+
+
+class TestModels:
+    def test_typosquat_check_result_entry_bool_and_add(self) -> None:
+        entry = TyposquatCheckResultEntry(dependency="left-pad")
+        assert not entry  # __bool__ should be False if no similars
+        entry.add("leftpad")
+        assert entry  # __bool__ should be True if similars exist
+        assert entry.similars == ["leftpad"]
+
+    def test_typosquat_check_result_entry_validation(self) -> None:
+        with pytest.raises(ValidationError):
+            TyposquatCheckResultEntry(dependency=None)
+
+    def test_typosquat_check_result_from_source_bool_contains_get_typosquats(self) -> None:
+        entry1 = TyposquatCheckResultEntry(dependency="foo", similars=["fou"])
+        entry2 = TyposquatCheckResultEntry(dependency="baz", similars=["bar"])
+        result = TyposquatCheckResultFromSource(errors=[entry1, entry2], source="npm")
+        assert result  # __bool__ should be True if any entry is True
+        assert entry1 in result
+        assert entry2 in result
+        assert result.get_typosquats() == {"foo", "baz"}
+
+    def test_typosquat_check_result_from_source_empty(self) -> None:
+        result = TyposquatCheckResultFromSource(errors=[], source="npm")
+        assert not result
+        assert result.get_typosquats() == set()
+
+    def test_typosquat_check_results_bool(self) -> None:
+        entry = TyposquatCheckResultEntry(dependency="foo", similars=["bar"])
+        result = TyposquatCheckResultFromSource(errors=[entry], source="npm")
+        results = TyposquatCheckResults(results=[result])
+        assert results
+        empty_results = TyposquatCheckResults(results=[])
+        assert not empty_results
+
+    def test_typosquat_check_results_from_source(self) -> None:
+        entry = TyposquatCheckResultEntry(dependency="foo", similars=["bar"])
+        result = TyposquatCheckResultFromSource(errors=[entry], source="npm")
+        results = TyposquatCheckResults(results=[result])
+
+        assert results.get_results_from_source("npm") == result
+        assert results.get_results_from_source("pypi") is None

--- a/tests/trusted_packages/test_trusted_packages.py
+++ b/tests/trusted_packages/test_trusted_packages.py
@@ -11,7 +11,7 @@ from twyn.trusted_packages.selectors import (
 )
 from twyn.trusted_packages.trusted_packages import (
     TrustedPackages,
-    TyposquatCheckResult,
+    TyposquatCheckResultEntry,
 )
 
 
@@ -117,6 +117,6 @@ class TestTrustedPackages:
             threshold_class=SimilarityThreshold,
         )
 
-        assert trusted_packages.get_typosquat(package_name=package_name) == TyposquatCheckResult(
+        assert trusted_packages.get_typosquat(package_name=package_name) == TyposquatCheckResultEntry(
             dependency=package_name, similars=matches
         )


### PR DESCRIPTION
Introduces the behaviour for supporting multiple lock files at once, as well as autodetecting them.

It does not yet support introducing multiple dependency files through the CLI.

It changes the json format output to https://github.com/elementsinteractive/twyn/pull/326/files#diff-ae0b15b531bda07c4292b5e4d8acb8b370f8a2e8c511a85ba548ad7d4491cc22R262

closes #325 

BREAKING CHANGE