### PR TITLE
feat: recursively look for lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ GitHub.sublime-settings
 .history
 /.ruff_cache/
 /.env.local
+
+# Test lock files
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - [Using `Twyn` as a cli tool](#using-twyn-as-a-cli-tool)
     - [Installation](#installation)
     - [Docker](#docker)
+    - [CLI Options Reference](#cli-options-reference)
     - [Run](#run)
     - [JSON Format](#json-format)
   - [Using `Twyn` as a library](#using-twyn-as-a-library)
@@ -61,15 +62,29 @@ docker pull elementsinteractive/twyn:latest
 docker run elementsinteractive/twyn --help
 ```
 
+##### CLI Options Reference
+
+| Option / Argument         | Type / Values                                      | Description                                                                                   |
+|--------------------------|----------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| `--config`               | `str` (path)                                       | Path to configuration file (`twyn.toml` or `pyproject.toml` by default).                      |
+| `--dependency-file`      | `str` (path)                                       | Dependency file to analyze. Supported: `requirements.txt`, `poetry.lock`, `uv.lock`, etc.     |
+| `--dependency`           | `str` (multiple allowed)                           | Dependency to analyze directly. Can be specified multiple times.                              |
+| `--selector-method`      | `all`, `first-letter`, `nearby-letter`             | Method for selecting possible typosquats.                                                     |
+| `--package-ecosystem`    | `pypi`, `npm`                                      | Package ecosystem for analysis.                                                               |
+| `-v`                     | flag                                               | Enable info-level logging.                                                                    |
+| `-vv`                    | flag                                               | Enable debug-level logging.                                                                   |
+| `--no-cache`             | flag                                               | Disable use of trusted packages cache. Always fetch from the source.                          |
+| `--no-track`             | flag                                               | Do not show the progress bar while processing packages.                                       |
+| `--json`                 | flag                                               | Display results in JSON format. Implies `--no-track`.                                         |
+| `-r`, `--recursive`      | flag                                               | Scan directories recursively for dependency files.                                            |
 #### Run
 
-To run twyn simply type:
+**Usage Example:**
 
 ```sh
 twyn run <OPTIONS>
 ```
-
-For a list of all the available options as well as their expected arguments run:
+or get help with
 
 ```sh
 twyn run --help
@@ -90,8 +105,8 @@ If `Twyn` was run by manually giving it dependencies (with `--dependency`), the 
 
 In any other case (when dependencies are parsed from a file), the source will be the path to the dependencies file. One entry will be created for every source.
 
-### Using Twyn as a library
 
+### Using Twyn as a library
 
 #### Installation
 `Twyn` also supports being used as 3rd party library for you project. To install it, run:
@@ -122,37 +137,6 @@ logging.basicConfig(level=logging.INFO)
 logging.getLogger("twyn").setLevel(logging.INFO)
 ```
 
-### Using Twyn as a library
-
-
-#### Installation
-`Twyn` also supports being used as 3rd party library for you project. To install it, run:
-
-
-```sh
-pip install twyn
-```
-
-Example usage in your code:
-
-```python
-from twyn import check_dependencies
-
-typos = check_dependencies()
-
-for typo in typos.errors:
-  print(f"Dependency:{typo.dependency}")
-  print(f"Did you mean any of [{','.join(typo.similars)}]")
-  
-```
-
-#### Logging level
-By default, logging is disabled when running as a 3rd party library. To override this behaviour, you can:
-
-```python
-logging.basicConfig(level=logging.INFO)
-logging.getLogger("twyn").setLevel(logging.INFO)
-```
 
 ## Configuration
 
@@ -268,5 +252,3 @@ To clear the cache, run:
 ```python
   twyn run cache clear
 ```
-
-

--- a/src/twyn/base/constants.py
+++ b/src/twyn/base/constants.py
@@ -35,6 +35,7 @@ DEFAULT_SELECTOR_METHOD = "all"
 DEFAULT_PROJECT_TOML_FILE = "pyproject.toml"
 DEFAULT_TWYN_TOML_FILE = "twyn.toml"
 DEFAULT_USE_CACHE = True
+DEFAULT_RECURSIVE = False
 
 
 PackageEcosystems: TypeAlias = Literal["pypi", "npm"]

--- a/src/twyn/cli.py
+++ b/src/twyn/cli.py
@@ -103,6 +103,13 @@ def entry_point() -> None:
     default=False,
     help="Display the results in json format. It implies --no-track.",
 )
+@click.option(
+    "-r",
+    "--recursive",
+    is_flag=True,
+    default=False,
+    help="Recursively look for files when trying to locate them automatically. Ignored if --dependency-file is given.",
+)
 def run(  # noqa: C901
     config: str,
     dependency_file: Optional[str],
@@ -114,6 +121,7 @@ def run(  # noqa: C901
     no_track: bool,
     json: bool,
     package_ecosystem: Optional[str],
+    recursive: bool,
 ) -> int:
     if vv:
         logger.setLevel(logging.DEBUG)
@@ -138,6 +146,7 @@ def run(  # noqa: C901
             show_progress_bar=False if json else not no_track,
             load_config_from_file=True,
             package_ecosystem=package_ecosystem,
+            recursive=recursive,
         )
     except TwynError as e:
         raise CliError(str(e)) from e

--- a/src/twyn/config/config_handler.py
+++ b/src/twyn/config/config_handler.py
@@ -8,6 +8,7 @@ from tomlkit import TOMLDocument, dumps, load, table
 
 from twyn.base.constants import (
     DEFAULT_PROJECT_TOML_FILE,
+    DEFAULT_RECURSIVE,
     DEFAULT_SELECTOR_METHOD,
     DEFAULT_TWYN_TOML_FILE,
     DEFAULT_USE_CACHE,
@@ -37,6 +38,7 @@ class TwynConfiguration:
     source: Optional[str]
     use_cache: bool
     package_ecosystem: Optional[PackageEcosystems]
+    recursive: Optional[bool]
 
 
 @dataclass
@@ -49,6 +51,7 @@ class ReadTwynConfiguration:
     source: Optional[str] = None
     use_cache: Optional[bool] = None
     package_ecosystem: Optional[PackageEcosystems] = None
+    recursive: Optional[bool] = None
 
 
 class ConfigHandler:
@@ -63,6 +66,7 @@ class ConfigHandler:
         dependency_file: Optional[str] = None,
         use_cache: Optional[bool] = None,
         package_ecosystem: Optional[PackageEcosystems] = None,
+        recursive: Optional[bool] = None,
     ) -> TwynConfiguration:
         """Resolve the configuration for Twyn.
 
@@ -95,6 +99,13 @@ class ConfigHandler:
         else:
             final_use_cache = DEFAULT_USE_CACHE
 
+        if recursive is not None:
+            final_recursive = use_cache
+        elif read_config.recursive is not None:
+            final_recursive = read_config.recursive
+        else:
+            final_recursive = DEFAULT_RECURSIVE
+
         return TwynConfiguration(
             dependency_file=dependency_file or read_config.dependency_file,
             selector_method=final_selector_method,
@@ -102,6 +113,7 @@ class ConfigHandler:
             source=read_config.source,
             use_cache=final_use_cache,
             package_ecosystem=package_ecosystem or read_config.package_ecosystem,
+            recursive=final_recursive,
         )
 
     def add_package_to_allowlist(self, package_name: str) -> None:

--- a/tests/config/test_config_handler.py
+++ b/tests/config/test_config_handler.py
@@ -42,6 +42,7 @@ class TestConfigHandler:
             source=None,
             use_cache=True,
             package_ecosystem=None,
+            recursive=False,
         )
 
     def test_config_raises_for_unknown_file(self) -> None:
@@ -103,6 +104,7 @@ class TestConfigHandler:
                     "selector_method": "all",
                     "allowlist": {},
                     "use_cache": False,
+                    "recursive": False,
                 },
             }
         }

--- a/tests/main/test_cli.py
+++ b/tests/main/test_cli.py
@@ -95,6 +95,7 @@ class TestCli:
                 show_progress_bar=True,
                 load_config_from_file=True,
                 package_ecosystem=None,
+                recursive=False,
             )
         ]
 
@@ -119,6 +120,7 @@ class TestCli:
                 show_progress_bar=True,
                 load_config_from_file=True,
                 package_ecosystem=None,
+                recursive=False,
             )
         ]
 
@@ -143,6 +145,7 @@ class TestCli:
                 show_progress_bar=True,
                 load_config_from_file=True,
                 package_ecosystem="pypi",
+                recursive=False,
             )
         ]
 
@@ -166,6 +169,7 @@ class TestCli:
                 show_progress_bar=True,
                 load_config_from_file=True,
                 package_ecosystem=None,
+                recursive=False,
             )
         ]
 
@@ -201,8 +205,39 @@ class TestCli:
                 show_progress_bar=True,
                 load_config_from_file=True,
                 package_ecosystem=None,
+                recursive=False,
             )
         ]
+
+    @patch("twyn.cli.check_dependencies")
+    def test_recursive(self, mock_check_dependencies: Mock) -> None:
+        runner = CliRunner()
+        runner.invoke(
+            cli.run,
+            [
+                "--recursive",
+            ],
+        )
+
+        runner.invoke(
+            cli.run,
+            [
+                "-r",
+            ],
+        )
+        call_args = call(
+            selector_method=None,
+            dependencies=None,
+            config_file=None,
+            dependency_file=None,
+            use_cache=None,
+            show_progress_bar=True,
+            load_config_from_file=True,
+            package_ecosystem=None,
+            recursive=True,
+        )
+        assert mock_check_dependencies.call_args_list[0] == call_args
+        assert mock_check_dependencies.call_args_list[1] == call_args
 
     @patch("twyn.cli.check_dependencies")
     def test_click_arguments_default(self, mock_check_dependencies: Mock) -> None:
@@ -219,6 +254,7 @@ class TestCli:
                 show_progress_bar=True,
                 load_config_from_file=True,
                 package_ecosystem=None,
+                recursive=False,
             )
         ]
 


### PR DESCRIPTION
With this PR we extend the functionality of parsing multiple files to also be able to auto locate them recursively, scanning subdirectories. Note that it will exclude `.git` directory to speed up the process.

closes #323 