### PR TITLE
feat: support multiple dependency files in config and cli

### DIFF
--- a/src/twyn/cli.py
+++ b/src/twyn/cli.py
@@ -47,6 +47,7 @@ def entry_point() -> None:
 @click.option(
     "--dependency-file",
     type=str,
+    multiple=True,
     help=(
         "Dependency file to analyze. By default, twyn will search in the current directory "
         "for supported files, but this option will override that behavior."
@@ -112,7 +113,7 @@ def entry_point() -> None:
 )
 def run(  # noqa: C901
     config: str,
-    dependency_file: Optional[str],
+    dependency_file: tuple[str],
     dependency: tuple[str],
     selector_method: str,
     v: bool,
@@ -133,15 +134,16 @@ def run(  # noqa: C901
             "Only one of --dependency or --dependency-file can be set at a time.", ctx=click.get_current_context()
         )
 
-    if dependency_file and not any(dependency_file.endswith(key) for key in DEPENDENCY_FILE_MAPPING):
-        raise click.UsageError("Dependency file name not supported.", ctx=click.get_current_context())
+    for dep_file in dependency_file:
+        if dep_file and not any(dep_file.endswith(key) for key in DEPENDENCY_FILE_MAPPING):
+            raise click.UsageError(f"Dependency file name {dep_file} not supported.", ctx=click.get_current_context())
 
     try:
         possible_typos = check_dependencies(
             selector_method=selector_method,
             dependencies=set(dependency) or None,
             config_file=config,
-            dependency_file=dependency_file,
+            dependency_files=set(dependency_file) or None,
             use_cache=not no_cache if no_cache is not None else no_cache,
             show_progress_bar=False if json else not no_track,
             load_config_from_file=True,

--- a/src/twyn/dependency_parser/dependency_selector.py
+++ b/src/twyn/dependency_parser/dependency_selector.py
@@ -12,8 +12,8 @@ logger = logging.getLogger("twyn")
 
 
 class DependencySelector:
-    def __init__(self, dependency_file: Optional[str] = None, root_path: str = ".") -> None:
-        self.dependency_file = dependency_file or ""
+    def __init__(self, dependency_files: Optional[set[str]] = None, root_path: str = ".") -> None:
+        self.dependency_files = dependency_files or set()
         self.root_path = root_path
 
     def auto_detect_dependency_file_parser(self) -> list[AbstractParser]:
@@ -38,18 +38,18 @@ class DependencySelector:
 
     def get_dependency_file_parsers_from_file_name(self) -> list[AbstractParser]:
         parsers = []
-        for known_dependency_file_name in DEPENDENCY_FILE_MAPPING:
-            if self.dependency_file.endswith(known_dependency_file_name):
-                file_parser = DEPENDENCY_FILE_MAPPING[known_dependency_file_name](self.dependency_file)
-                parsers.append(file_parser)
-
+        for dependency_file in self.dependency_files:
+            for known_dependency_file_name in DEPENDENCY_FILE_MAPPING:
+                if dependency_file.endswith(known_dependency_file_name):
+                    file_parser = DEPENDENCY_FILE_MAPPING[known_dependency_file_name](dependency_file)
+                    parsers.append(file_parser)
         if not parsers:
             raise NoMatchingParserError
 
         return parsers
 
     def get_dependency_parsers(self) -> list[AbstractParser]:
-        if self.dependency_file:
+        if self.dependency_files:
             logger.debug("Dependency file provided. Assigning a parser.")
             return self.get_dependency_file_parsers_from_file_name()
 

--- a/tests/config/test_config_handler.py
+++ b/tests/config/test_config_handler.py
@@ -1,7 +1,6 @@
 import dataclasses
 from copy import deepcopy
 from pathlib import Path
-from typing import NoReturn
 from unittest.mock import Mock, patch
 
 import pytest
@@ -26,17 +25,14 @@ from tests.conftest import create_tmp_file
 
 
 class TestConfigHandler:
-    def throw_exception(self) -> NoReturn:
-        raise PathNotFoundError
-
     @patch("twyn.file_handler.file_handler.FileHandler.read")
     def test_no_enforce_file_on_non_existent_file(self, mock_is_file: Mock) -> None:
         """Resolving the config without enforcing the file to be present gives you defaults."""
-        mock_is_file.side_effect = self.throw_exception
+        mock_is_file.side_effect = PathNotFoundError()
         config = ConfigHandler(FileHandler(DEFAULT_PROJECT_TOML_FILE)).resolve_config()
 
         assert config == TwynConfiguration(
-            dependency_file=None,
+            dependency_files=set(),
             selector_method="all",
             allowlist=set(),
             source=None,
@@ -51,7 +47,7 @@ class TestConfigHandler:
 
     def test_read_config_values(self, pyproject_toml_file: Path) -> None:
         config = ConfigHandler(file_handler=FileHandler(pyproject_toml_file)).resolve_config()
-        assert config.dependency_file == "my_file.txt"
+        assert config.dependency_files == {"my_file.txt", "my_other_file.txt"}
         assert config.selector_method == "all"
         assert config.allowlist == {"boto4", "boto2"}
         assert config.use_cache is False
@@ -62,7 +58,7 @@ class TestConfigHandler:
         toml = handler._read_toml()
         twyn_data = ConfigHandler(FileHandler(pyproject_toml_file))._get_read_config(toml)
         assert twyn_data == ReadTwynConfiguration(
-            dependency_file="my_file.txt",
+            dependency_files={"my_file.txt", "my_other_file.txt"},
             selector_method="all",
             allowlist={"boto4", "boto2"},
             source=None,
@@ -75,7 +71,7 @@ class TestConfigHandler:
 
         initial_config = handler.resolve_config()
         to_write = deepcopy(initial_config)
-        to_write = dataclasses.replace(to_write, allowlist={})
+        to_write = dataclasses.replace(to_write, allowlist=set(), dependency_files=set())
 
         handler._write_config(toml, to_write)
 
@@ -100,9 +96,7 @@ class TestConfigHandler:
                     "scripts": {"twyn": "twyn.cli:entry_point"},
                 },
                 "twyn": {
-                    "dependency_file": "my_file.txt",
                     "selector_method": "all",
-                    "allowlist": {},
                     "use_cache": False,
                     "recursive": False,
                 },
@@ -141,7 +135,7 @@ class TestConfigHandler:
         config = ConfigHandler().resolve_config()
 
         assert config.allowlist == set()
-        assert config.dependency_file is None
+        assert config.dependency_files == set()
         assert config.use_cache is True
         assert config.selector_method == DEFAULT_SELECTOR_METHOD
         assert config.source is None
@@ -260,3 +254,15 @@ class TestAllowlistConfigHandler:
         error_message = str(exc_info.value)
         assert "Invalid selector_method 'invalid-selector'" in error_message
         assert "Must be one of: all, first-letter, nearby-letter" in error_message
+
+    def test_load_single_dependency_file(self, tmp_path: Path) -> None:
+        pyproject_toml = tmp_path / "pyproject.toml"
+        data = """
+        [tool.twyn]
+        dependency_file="requirements.txt"
+        """
+        pyproject_toml.write_text(data)
+
+        config = ConfigHandler(FileHandler(str(pyproject_toml))).resolve_config()
+
+        assert config.dependency_files == {"requirements.txt"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,7 +237,7 @@ def pyproject_toml_file(tmp_path: Path) -> Iterator[Path]:
     twyn = "twyn.cli:entry_point"
 
     [tool.twyn]
-    dependency_file="my_file.txt"
+    dependency_file=["my_file.txt", "my_other_file.txt"]
     selector_method="all"
     logging_level="debug"
     allowlist=["boto4", "boto2"]

--- a/tests/dependency_parser/test_dependency_selector.py
+++ b/tests/dependency_parser/test_dependency_selector.py
@@ -28,14 +28,16 @@ class TestDependencySelector:
             ("/some/path/package-lock.json", PackageLockJsonParser),
         ],
     )
-    def test_get_dependency_parser(self, file_name: str, parser_class: type[AbstractParser]):
-        parser = DependencySelector(file_name).get_dependency_parsers()
+    def test_get_dependency_parser(self, file_name: str, parser_class: type[AbstractParser]) -> None:
+        parser = DependencySelector({file_name}).get_dependency_parsers()
         assert len(parser) == 1
 
         assert isinstance(parser[0], parser_class)
         assert str(parser[0].file_handler.file_path).endswith(file_name)
 
-    def test_get_dependency_parser_auto_detect_requirements_file(self, requirements_txt_file: Path, tmp_path: Path):
+    def test_get_dependency_parser_auto_detect_requirements_file(
+        self, requirements_txt_file: Path, tmp_path: Path
+    ) -> None:
         parser = DependencySelector("", root_path=str(tmp_path)).get_dependency_parsers()
         assert isinstance(parser[0], RequirementsTxtParser)
 

--- a/tests/main/conftest.py
+++ b/tests/main/conftest.py
@@ -8,6 +8,6 @@ import pytest
 @pytest.fixture(scope="module")
 def disable_track() -> Generator[None, Any, None]:
     """Disables the track UI for running tests."""
-    with patch("rich.progress.track") as m_track:
+    with patch("rich.progress.track") as m_track, patch("click.echo"):
         m_track.side_effect = lambda iterable, description: iterable
         yield

--- a/tests/main/test_cli.py
+++ b/tests/main/test_cli.py
@@ -88,7 +88,7 @@ class TestCli:
         assert mock_check_dependencies.call_args_list == [
             call(
                 config_file="my-config",
-                dependency_file="requirements.txt",
+                dependency_files={"requirements.txt"},
                 dependencies=None,
                 selector_method="first-letter",
                 use_cache=None,
@@ -113,7 +113,7 @@ class TestCli:
         assert mock_check_dependencies.call_args_list == [
             call(
                 config_file=None,
-                dependency_file="/path/requirements.txt",
+                dependency_files={"/path/requirements.txt"},
                 dependencies=None,
                 selector_method=None,
                 use_cache=None,
@@ -138,7 +138,7 @@ class TestCli:
         assert mock_check_dependencies.call_args_list == [
             call(
                 config_file=None,
-                dependency_file=None,
+                dependency_files=None,
                 dependencies=None,
                 selector_method=None,
                 use_cache=None,
@@ -162,7 +162,7 @@ class TestCli:
         assert mock_check_dependencies.call_args_list == [
             call(
                 config_file=None,
-                dependency_file=None,
+                dependency_files=None,
                 dependencies={"reqests"},
                 selector_method=None,
                 use_cache=None,
@@ -198,7 +198,7 @@ class TestCli:
         assert mock_check_dependencies.call_args_list == [
             call(
                 config_file=None,
-                dependency_file=None,
+                dependency_files=None,
                 dependencies={"reqests", "reqeusts"},
                 selector_method=None,
                 use_cache=None,
@@ -229,7 +229,7 @@ class TestCli:
             selector_method=None,
             dependencies=None,
             config_file=None,
-            dependency_file=None,
+            dependency_files=None,
             use_cache=None,
             show_progress_bar=True,
             load_config_from_file=True,
@@ -247,7 +247,7 @@ class TestCli:
         assert mock_check_dependencies.call_args_list == [
             call(
                 config_file=None,
-                dependency_file=None,
+                dependency_files=None,
                 selector_method=None,
                 dependencies=None,
                 use_cache=None,
@@ -328,7 +328,7 @@ class TestCli:
 
         assert isinstance(result.exception, SystemExit)
         assert result.exit_code == 2
-        assert "Dependency file name not supported." in result.output
+        assert "Dependency file name requirements-dev.txt not supported." in result.output
 
     @patch("twyn.cli.check_dependencies")
     def test_custom_twyn_error_is_caught_and_wrapped_in_cli_error(self, mock_check_dependencies, caplog):


### PR DESCRIPTION
This PRs  allows the user to set multiple files both via the cli and the config file.

In a future PR we will validate the types of the config fields.

 refs #325 