### PR TITLE
build: add tag with major version

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -64,6 +64,12 @@ runs:
       uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
       with:
         images: ${{ inputs['image-name'] }}
+        tags: |
+          type=semver,enable=true,pattern={{raw}}
+          type=semver,enable=true,pattern={{major}},prefix=v
+          type=ref,event=pr,prefix=pr-,enable=true
+          type=ref,event=branch,branch=main,pattern={{raw}}
+          type=ref,event=branch,branch=main,pattern={{major}},prefix=v
 
     - name: Build Docker image
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0


### PR DESCRIPTION
Add a tag to the built Docker image with its associated major version number. This will allow users to get minor and patch updates for free without having to manually change anything in their pipelines.

i.e. if the current version was `v1.2.3`, we're now adding a new `v1` tag, along with all the previous ones (`v1.2.3`, `latest`).

closes #388 