### PR TITLE
fix: raise custom exception on an invalid selector method

### DIFF
--- a/src/twyn/main.py
+++ b/src/twyn/main.py
@@ -272,14 +272,14 @@ def _get_dependencies_list(
         raise InvalidArgumentsError(
             "Cannot show progress bar because `rich` and `click` dependencies are not installed. "
             "It is only meant to be shown when running `twyn` as a cli tool. "
-            "If this is you case, install all the dependencies with `pip install twyn[cli]`. "
+            "If this is your case, install all the dependencies with `pip install twyn[cli]`. "
         ) from e
 
 
 def _get_selector_method(selector_method: str) -> SelectorMethod:
     """Return the selector_method from set of available ones."""
     if selector_method not in SELECTOR_METHOD_MAPPING:
-        InvalidSelectorMethodError("Invalid selector method")
+        raise InvalidSelectorMethodError("Invalid selector method")
 
     return SELECTOR_METHOD_MAPPING[selector_method]()
 

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -163,6 +163,11 @@ class TestCheckDependencies:
             ]
         )
 
+    def test_check_dependencies_fails_if_unkown_selector_method(self) -> None:
+        """Check that if an invalid selector method is given, it raises InvalidSelectorMethodError."""
+        with pytest.raises(InvalidSelectorMethodError):
+            check_dependencies(selector_method="asfd")
+
     @patch("twyn.trusted_packages.TopPyPiReference.get_packages")
     def test_check_dependencies_detects_typosquats_from_file_and_language_is_set(
         self, mock_get_packages: Mock, uv_lock_file_with_typo: Path


### PR DESCRIPTION
There was an open with this fix, but the user who created it closed the PR. 

